### PR TITLE
Fix invite user template bug

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,15 @@
 class ApplicationMailer < ActionMailer::Base
   default from: 'help@beacon.support'
   layout 'mailer'
+  helper_method :logo_path
+
+  private
+
+    def load_council_config
+      Rails.configuration.councils[ENV['COUNCIL'] || :demo]
+    end
+
+    def logo_path
+      load_council_config[:logo_path]
+    end
 end


### PR DESCRIPTION
Fixes bug created by #53 where invite email template rendering failed due to `logo_path` being undefined.