### PR TITLE
Remove broken logo from emails

### DIFF
--- a/app/views/passwordless/mailer/magic_link.html.erb
+++ b/app/views/passwordless/mailer/magic_link.html.erb
@@ -20,8 +20,6 @@
 </head>
 <body>
 
-    <%= image_tag logo_path, alt: "logo", width: "250px; margin-bottom: 35px" %>
-
     <p>Click the link to finish signing into Beacon:</p>
 
     <p><a href="<%=  @magic_link %>">Finish signing in</a></p>

--- a/app/views/user_sign_in_mailer/send_invite_email.html.erb
+++ b/app/views/user_sign_in_mailer/send_invite_email.html.erb
@@ -10,8 +10,6 @@
 </head>
 <body>
 
-  <%= image_tag logo_path, alt: "logo", width: "250px; margin-bottom: 35px" %>
-
   <p>You've been invited to view and manage data on the council's platform for tracking vulnerable people in the area.</p>
   
   <p>Click the link below to start signing in:</p>


### PR DESCRIPTION
This is rendered as a relative URL; a full URL is needed for emails, including the hostname. We could get around that by using `ENV['MAILER_URL']` with an `https://` prefix,but rails docs recommend this way: https://guides.rubyonrails.org/action_mailer_basics.html#adding-images-in-action-mailer-views
Removing it in the meantime as having a broken image probably isn't helping our spam score 😬

@jhackett1 if you're up for getting the logo to work, feel free to close this PR. Just thought we'd do this in the meantime.