### PR TITLE
Support review apps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,8 @@ gem 'webpacker', '~> 4.0'
 gem 'sendgrid_actionmailer_adapter'
 gem 'strong_migrations'
 gem 'csv'
+gem 'factory_bot_rails', require: false
+gem 'faker', require: false
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
@@ -39,8 +41,6 @@ group :test do
 end
 
 group :development, :test do
-  gem 'factory_bot_rails'
-  gem 'faker'
   gem 'pry-byebug'
   gem 'pry-rails'
   gem 'rspec-rails', '~> 4.0.0'

--- a/README.md
+++ b/README.md
@@ -77,5 +77,5 @@ Coming soon...
 | SMTP_PORT        | Port for SMTP server                |
 | COUNCIL          | Config key for `councils.yml`       |
 | SENDGRID_API_KEY | Sendgrid API key (production only   |
-| MAILER_URL       | Default URL for action mailer       |
+| HOSTNAME         | Optional hostname used in outbound emails (e.g. `x.beacon.com`) |
 | SEED_USER_EMAILS | Optional comma-separated list of emails to seed users table with |

--- a/README.md
+++ b/README.md
@@ -78,3 +78,4 @@ Coming soon...
 | COUNCIL          | Config key for `councils.yml`       |
 | SENDGRID_API_KEY | Sendgrid API key (production only   |
 | MAILER_URL       | Default URL for action mailer       |
+| SEED_USER_EMAILS | Optional comma-separated list of emails to seed users table with |

--- a/app.json
+++ b/app.json
@@ -1,4 +1,11 @@
 {
   "name": "Beacon",
-  "description": "This is a tool for local authorities and voluntary organisations to record and triage the needs of vulnerable people in their jurisdiction, and assign those needs to those who can meet them."
+  "description": "This is a tool for local authorities and voluntary organisations to record and triage the needs of vulnerable people in their jurisdiction, and assign those needs to those who can meet them.",
+  "environments": {
+    "review": {
+      "scripts": {
+        "postdeploy": "rails db:seed"
+      }
+    }
+  }
 }

--- a/app/views/user_sign_in_mailer/send_invite_email.html.erb
+++ b/app/views/user_sign_in_mailer/send_invite_email.html.erb
@@ -14,11 +14,11 @@
   
   <p>Click the link below to start signing in:</p>
   
-  <p><a href="https://<%= ENV['MAILER_URL'] %>">Visit Beacon</a></p>
+  <p><a href="<%= root_url %>">Visit Beacon</a></p>
 
   <p>If you can't see the link, copy and paste this URL into your browser:</p>
 
-  <p>https://<%= ENV['MAILER_URL'] %></p>
+  <p><%= root_url %></p>
 
 </body>
 </html>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,7 +36,7 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  config.action_mailer.default_url_options = { host: ENV['MAILER_URL'] || 'localhost:3000' }
+  config.action_mailer.default_url_options = { host: ENV['HOSTNAME'] || 'localhost:3000' }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -7,7 +7,7 @@ Rails.application.configure do
   # use sendgrid to send emails
   config.action_mailer.delivery_method = SendGridActionMailerAdapter::DeliveryMethod
 
-  config.action_mailer.default_url_options = { host: ENV['MAILER_URL'] }
+  config.action_mailer.default_url_options = { host: ENV['HOSTNAME'] || (ENV['HEROKU_APP_NAME'] && "#{ENV['HEROKU_APP_NAME']}.herokuapp.com") }
 
   # Code is not reloaded between requests.
   config.cache_classes = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -35,6 +35,8 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  config.action_mailer.default_url_options = { host: ENV['HOSTNAME'] || 'localhost:3000' }
+
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -44,9 +44,9 @@ end
 # make an initial user for sake of the readme
 seed_user_emails = ENV['SEED_USER_EMAILS'] || 'admin@example.com'
 seed_user_emails.split(',').each do |email|
-  User.create(
-    email: email.strip,
-    admin: true,
-    invited: DateTime.now
-  )
+  User.find_or_initialize_by(email: email.strip)
+    .update!(
+      admin: true,
+      invited: DateTime.now
+    )
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,6 +5,9 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+require 'faker'
+require 'factory_bot'
+FactoryBot.find_definitions
 
 ActiveRecord::Base.transaction do
   puts "Seeding the database..."

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -42,10 +42,11 @@ ActiveRecord::Base.transaction do
 end
 
 # make an initial user for sake of the readme
-User.create(
-  email: "admin@example.com",
-  first_name: "Example",
-  last_name: "User",
-  admin: true,
-  invited: "2020-03-25 00:00:00"
-)
+seed_user_emails = ENV['SEED_USER_EMAILS'] || 'admin@example.com'
+seed_user_emails.split(',').each do |email|
+  User.create(
+    email: email.strip,
+    admin: true,
+    invited: DateTime.now
+  )
+end

--- a/spec/mailers/user_sign_in_mailer_spec.rb
+++ b/spec/mailers/user_sign_in_mailer_spec.rb
@@ -1,6 +1,11 @@
 require "rails_helper"
 
 RSpec.describe UserSignInMailer, type: :mailer do
+
+  before do
+    Rails.application.reload_routes!
+  end
+
   describe 'send invite email' do
     let(:user) { double User, email: 'test@emailaddress.com' }
     let(:mail) { described_class.send_invite_email(user).deliver }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,8 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 require 'paper_trail/frameworks/rspec'
+require 'factory_bot'
+require 'faker'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
@@ -22,6 +24,9 @@ require 'paper_trail/frameworks/rspec'
 # require only the support files necessary.
 #
 # Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+
+# Tell FactoryBot to find factories since Gemfile uses require: false
+FactoryBot.find_definitions
 
 begin
   ActiveRecord::Migration.maintain_test_schema!


### PR DESCRIPTION
This will allow us to run `db:seed` in production without loading factorbot+faker when the server runs, and that command will seed the users table with any emails specified in the env var. And the hostnames in emails will work on review apps.

Just need to add a command to the heroku config so that review apps run `db:seed` when they're created, but that can be a separate PR.