### PR TITLE
Feature/187 refactor needscontroller to separate logic

### DIFF
--- a/app/controllers/needs_controller.rb
+++ b/app/controllers/needs_controller.rb
@@ -8,9 +8,7 @@ class NeedsController < ApplicationController
   def index
     @params = params.permit(:user_id, :status, :category, :page, :order_dir, :order, :commit, :is_urgent)
     @users = User.all
-    @needs = Need.filter(@params.slice(:category, :user_id, :status, :is_urgent))
-                 .sorted_by(@params.slice(:order, :order_dir))
-
+    @needs = Need.filter_and_sort(@params.slice(:category, :user_id, :status, :is_urgent), @params.slice(:order, :order_dir))
     @needs = @needs.page(params[:page]) unless request.format == 'csv'
     respond_to do |format|
       format.html

--- a/app/controllers/needs_controller.rb
+++ b/app/controllers/needs_controller.rb
@@ -20,28 +20,11 @@ class NeedsController < ApplicationController
   end
 
   def new
-    @needs = Needs.new
+    @needs = NeedsListForm.new
   end
 
   def create
-    needs_params["needs_list"].each do |_, value|
-      if value["active"] == "true"
-        need_category = value["name"].humanize.downcase
-        need_description = value["description"]
-        if need_description.blank?
-          need_description = "#{@contact.name} needs #{need_category}"
-        end
-
-        need_is_urgent = value["is_urgent"]
-
-        @contact.needs.build(category: need_category, name: need_description, is_urgent: need_is_urgent, due_by: DateTime.now + 7.days).save
-      end
-    end
-
-    if needs_params["other_need"]
-      @contact.needs.build(category: "other", name: needs_params["other_need"], due_by: DateTime.now + 7.days).save
-    end
-
+    NeedsCreator.create_needs(@contact, needs_form_params["needs_list"], needs_form_params["other_need"])
     redirect_to controller: :contacts, action: :show_needs, id: @contact.id
   end
 
@@ -73,7 +56,7 @@ class NeedsController < ApplicationController
     params.require(:need).permit(:name, :status, :user_id, :category, :is_urgent)
   end
 
-  def needs_params
-    params.require(:needs).permit!
+  def needs_form_params
+    params.require(:needs_list_form).permit!
   end
 end

--- a/app/controllers/needs_controller.rb
+++ b/app/controllers/needs_controller.rb
@@ -8,21 +8,10 @@ class NeedsController < ApplicationController
   def index
     @params = params.permit(:user_id, :status, :category, :page, :order_dir, :order, :commit, :is_urgent)
     @users = User.all
-    @needs = Need.includes(:contact, :user)
-    @needs = @needs.filter_by_category(params[:category]) if params[:category].present?
-    @needs = @needs.filter_by_user_id(params[:user_id]) if params[:user_id].present?
-    @needs = @needs.filter_by_status(params[:status]) if params[:status].present?
-    @needs = @needs.filter_by_is_urgent(params[:is_urgent]) if params[:is_urgent].present?
+    @needs = Need.filter(@params.slice(:category, :user_id, :status, :is_urgent))
+                 .sorted_by(@params.slice(:order, :order_dir))
 
-    if params[:order].present? && params[:order_dir].present?
-      sort_column = Need.column_names.include?(params[:order]) ? params[:order] : 'created_at'
-      sort_order = %w(asc desc).include?(params[:order_dir].downcase) ? params[:order_dir] : 'desc'
-      @needs = @needs.order("#{sort_column} #{sort_order}")
-    else
-      @needs = @needs.order(created_at: :desc)
-    end
     @needs = @needs.page(params[:page]) unless request.format == 'csv'
-
     respond_to do |format|
       format.html
       format.csv { send_data @needs.to_csv, filename: "needs-#{Date.today}.csv" }

--- a/app/models/concerns/filterable.rb
+++ b/app/models/concerns/filterable.rb
@@ -1,0 +1,29 @@
+module Filterable
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def filter(filtering_params)
+      results = base_query
+      filtering_params.each do |key, value|
+        results = results.public_send("filter_by_#{key}", value) if value.present?
+      end
+      results
+    end
+
+    def sorted_by(order_params)
+      return default_sort unless order_params[:order].present? && order_params[:order_dir].present?
+      return default_sort unless column_names.include?(order_params[:order])
+      return default_sort unless %w(asc desc).include?(order_params[:order_dir].downcase)
+      order("#{order_params[:order]} #{order_params[:order_dir]}")
+      self
+    end
+
+    def default_sort
+      self
+    end
+
+    def base_query
+      self.where(nil)
+    end
+  end
+end

--- a/app/models/concerns/filterable.rb
+++ b/app/models/concerns/filterable.rb
@@ -2,26 +2,43 @@ module Filterable
   extend ActiveSupport::Concern
 
   module ClassMethods
-    def filter(filtering_params)
+
+    # Filter and sort an ActiveRecord table with the provided params
+    # Include on an ApplicationRecord object via:
+    # 'include Filterable'
+    #
+    # Filter and sort on parameters like:
+    # 'ObjectName.filter_and_sort(params.slice(:example1), params.slice(:order, :order_dir))'
+    #
+    # Override #default_sort to modify the default sort order if no/invalid order params are supplied
+    # Override #base_query to change the root query for the table, e.g. to include relations
+    #
+    # @param filtering_params The parameters to filter the table on
+    # @param ordering_params The parameters to order the table on
+    def filter_and_sort(filtering_params, ordering_params)
       results = base_query
       filtering_params.each do |key, value|
         results = results.public_send("filter_by_#{key}", value) if value.present?
       end
+
+      # filter field and direction to known values
+      order_field = ordering_params[:order]
+      order_direction = ordering_params[:order_dir]
+      return default_sort(results) unless order_field.present? && order_direction.present?
+      return default_sort(results) unless column_names.include?(order_field)
+      return default_sort(results) unless %w(asc desc).include?(order_direction.downcase)
+
+      # check for overridden order scope
+      return results.public_send("order_by_#{order_field}", order_direction) if respond_to?("order_by_#{order_field}")
+      results.order("#{ordering_params[:order]} #{ordering_params[:order_dir]}")
+    end
+
+    # define a default sort order on a query
+    def default_sort(results)
       results
     end
 
-    def sorted_by(order_params)
-      return default_sort unless order_params[:order].present? && order_params[:order_dir].present?
-      return default_sort unless column_names.include?(order_params[:order])
-      return default_sort unless %w(asc desc).include?(order_params[:order_dir].downcase)
-      order("#{order_params[:order]} #{order_params[:order_dir]}")
-      self
-    end
-
-    def default_sort
-      self
-    end
-
+    # define a base query for the type
     def base_query
       self.where(nil)
     end

--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -12,6 +12,7 @@ class Need < ApplicationRecord
   scope :completed, -> { where.not(completed_on: nil) }
   scope :uncompleted, -> { where(completed_on: nil) }
   scope :filter_by_category, -> (category) { where(category: category.downcase) }
+
   scope :filter_by_user_id, -> (user_id) do
     if user_id == "Unassigned"
       where(user_id: nil)
@@ -19,6 +20,7 @@ class Need < ApplicationRecord
       where(user_id: user_id)
     end
   end
+
   scope :filter_by_status, -> (status) do
     status = status.downcase
       if status == 'to do'
@@ -26,7 +28,8 @@ class Need < ApplicationRecord
       else
         where.not(completed_on: nil)
       end
-    end
+  end
+
   scope :filter_by_is_urgent, -> (is_urgent) do
     is_urgent = is_urgent.downcase
       if is_urgent == 'urgent'
@@ -34,7 +37,11 @@ class Need < ApplicationRecord
       else
         where.not(is_urgent: true)
       end
-    end
+  end
+
+  scope :order_by_category, -> (direction) do
+    order("LOWER(category) #{direction}")
+  end
 
   counter_culture :contact,
                   column_name: proc { |model| model.completed_on ? 'completed_needs_count' : 'uncompleted_needs_count' },
@@ -74,11 +81,11 @@ class Need < ApplicationRecord
     save
   end
 
-  def base_query
-    self.include(:contact, :user)
+  def self.base_query
+    Need.includes(:contact, :user)
   end
 
-  def default_sort
-    order(created_by: :asc)
+  def self.default_sort(results)
+    results.order(created_at: :asc)
   end
 end

--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -1,7 +1,8 @@
-
 require 'csv'
 
 class Need < ApplicationRecord
+  include Filterable
+
   belongs_to :contact, counter_cache: true
   belongs_to :user, optional: true
   has_many :notes, dependent: :destroy
@@ -71,5 +72,13 @@ class Need < ApplicationRecord
                           ''
                         end
     save
+  end
+
+  def base_query
+    self.include(:contact, :user)
+  end
+
+  def default_sort
+    order(created_by: :asc)
   end
 end

--- a/app/models/needs_list_form.rb
+++ b/app/models/needs_list_form.rb
@@ -1,4 +1,4 @@
-class Needs
+class NeedsListForm
   include ActiveModel::Model
 
   attr_accessor :needs_list

--- a/app/services/needs_creator.rb
+++ b/app/services/needs_creator.rb
@@ -1,0 +1,26 @@
+# Creates needs for a user from a submitted questionnaire form
+class NeedsCreator
+  def self.create_needs(contact, needs_form, other_need)
+    needs_form.each do |_, value|
+      next unless value["active"] == "true"
+      need_hash = create_need(contact, value)
+      contact.needs.build(need_hash.merge(due_by: DateTime.now + 7.days)).save
+    end
+
+    if other_need
+      contact.needs.build(category: "other", name: other_need, due_by: DateTime.now + 7.days).save
+    end
+  end
+
+  def self.create_need(contact, need_values)
+    need_hash = Hash.new
+    need_hash[:category] = need_values["name"].humanize.downcase
+    need_hash[:name] = if need_values["description"].blank?
+                       "#{contact.name} needs #{need_hash[:category]}"
+                     else
+                       need_values["description"]
+                     end
+    need_hash[:is_urgent] = need_values["is_urgent"]
+    need_hash
+  end
+end

--- a/app/services/needs_creator.rb
+++ b/app/services/needs_creator.rb
@@ -14,13 +14,13 @@ class NeedsCreator
 
   def self.create_need(contact, need_values)
     need_hash = Hash.new
-    need_hash[:category] = need_values["name"].humanize.downcase
-    need_hash[:name] = if need_values["description"].blank?
+    need_hash[:category] = need_values['name'].humanize.downcase
+    need_hash[:name] = if need_values['description'].blank?
                        "#{contact.name} needs #{need_hash[:category]}"
-                     else
-                       need_values["description"]
-                     end
-    need_hash[:is_urgent] = need_values["is_urgent"]
+                       else
+                       need_values['description']
+                       end
+    need_hash[:is_urgent] = need_values['is_urgent']
     need_hash
   end
 end

--- a/spec/concerns/filterable_concern_spec.rb
+++ b/spec/concerns/filterable_concern_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+require 'spec_helper'
+
+class ExampleFilterable < ApplicationRecord
+  include Filterable
+end
+
+RSpec.describe ExampleFilterable do
+  let(:mock_query) { double(ActiveRecord::Relation) }
+  before do
+    allow(ExampleFilterable).to receive(:base_query).and_return(mock_query)
+    allow(ExampleFilterable).to receive(:column_names).and_return(%w(field_a field_b))
+  end
+
+  it "orders by default_sort if no order params are provided" do
+    expect(ExampleFilterable).to receive(:default_sort)
+    ExampleFilterable.filter_and_sort({}, {})
+  end
+
+  it "orders by the provided order params" do
+    expect(mock_query).to receive(:order).with("field_a asc")
+    ExampleFilterable.filter_and_sort({}, { :order => "field_a", :order_dir => "asc"})
+  end
+
+  it "defaults to default_sort if sorted on a column that is not allowed" do
+    allow(ExampleFilterable).to receive(:column_names).and_return([])
+    expect(ExampleFilterable).to receive(:default_sort)
+    ExampleFilterable.filter_and_sort({}, { :order => "field_a", :order_dir => "asc"})
+  end
+
+  it "defaults to default_sort if order_dir is not valid" do
+    expect(ExampleFilterable).to receive(:default_sort)
+    ExampleFilterable.filter_and_sort({}, { :order => "field_a", :order_dir => "NOT_VALID"})
+  end
+
+  it "filters on allow fields" do
+    allow(ExampleFilterable).to receive(:column_names).and_return(["allowed_field"])
+    expect(mock_query).to receive(:filter_by_allowed_field).with("value").and_return(mock_query)
+    ExampleFilterable.filter_and_sort({ :allowed_field => "value" }, {})
+  end
+end

--- a/spec/controllers/needs_controller_spec.rb
+++ b/spec/controllers/needs_controller_spec.rb
@@ -5,9 +5,7 @@ class NeedsTestController < NeedsController
   skip_before_action :require_user!
 end
 
-
 RSpec.describe NeedsTestController do
-
   before(:each) do
     # test route
     routes.draw do
@@ -67,52 +65,16 @@ RSpec.describe NeedsTestController do
   end
 
   describe "POST #create" do
-
     before(:each) do
-      controller.instance_variable_set(:@current_user, {})
-
-      @builder = double(ActiveRecord::Associations::CollectionProxy)
-      allow(@builder).to receive_messages(build: @builder, save: @builder)
-
       @test_contact = double("Contact")
       allow(@test_contact).to receive(:id).and_return 1
-      allow(@test_contact).to receive(:name).and_return "Contact name"
-      allow(@test_contact).to receive(:needs).and_return @builder
-
       @contact = class_double("Contact").as_stubbed_const
       allow(@contact).to receive(:find).and_return(@test_contact)
     end
 
-    it "saves each active need" do
-      # three needs, first two active
-      needs_list = [1,2,3].map{|i| [i, { active: [1,2].include?(i), name: "category" }]}.to_h
-
-      expect(@builder).to receive(:save).twice
-      post :create, params: { contact_id: 1, :needs => {:needs_list => needs_list}}
-      expect(response).to redirect_to controller: :contacts, action: :show_needs, id: 1
-    end
-
-    it "sets a default description if none is provided" do
-      needs_list = {1 => { active: true, name: "category" }}
-
-      expect(@builder).to receive(:build).with(hash_including(:name => "Contact name needs category")).once
-      post :create, params: { contact_id: 1, :needs => {:needs_list => needs_list}}
-      expect(response).to redirect_to controller: :contacts, action: :show_needs, id: 1
-    end
-
-    it "sets the description from the provided description if provided" do
-      needs_list = {1 => { active: true, name: "category", description: "test description" }}
-
-      expect(@builder).to receive(:build).with(hash_including(:name => "test description")).once
-      post :create, params: { contact_id: 1, :needs => {:needs_list => needs_list}}
-      expect(response).to redirect_to controller: :contacts, action: :show_needs, id: 1
-    end
-
-    it "adds an 'other' need if a description is provided" do
+    it "redirects to the contacts needs list for the given contact" do
       needs_list = { 1 => { active: false }}
-
-      expect(@builder).to receive(:build).with(hash_including(:name => "test other description")).once
-      post :create, params: { contact_id: 1, :needs => {:needs_list => needs_list, :other_need => "test other description"}}
+      post :create, params: { contact_id: 1, :needs_list_form => {:needs_list => needs_list }}
       expect(response).to redirect_to controller: :contacts, action: :show_needs, id: 1
     end
   end

--- a/spec/services/needs_creator_spec.rb
+++ b/spec/services/needs_creator_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe NeedsCreator do
+  before(:each) do
+    @builder = double(ActiveRecord::Associations::CollectionProxy)
+    allow(@builder).to receive_messages(build: @builder, save: @builder)
+
+    @test_contact = double('Contact')
+    allow(@test_contact).to receive(:id).and_return 1
+    allow(@test_contact).to receive(:name).and_return 'Contact name'
+    allow(@test_contact).to receive(:needs).and_return @builder
+  end
+
+  it 'saves each active need' do
+    # three needs, first two active
+    needs_list = {
+        '1' => {'active' => 'true', 'name' => 'category1'},
+        '2' => {'active' => 'true', 'name' => 'category2'},
+        '3' => {'active' => 'false', 'name' => 'category3'},
+    }
+    expect(@builder).to receive(:save).twice
+    described_class.create_needs(@test_contact, needs_list, nil)
+  end
+
+  it "sets a default description if none is provided" do
+    needs_list = {'1' => {'active' => 'true', 'name' => 'category'} }
+
+    expect(@builder).to receive(:build).with(hash_including(:name => "Contact name needs category")).once
+    described_class.create_needs(@test_contact, needs_list, nil)
+  end
+
+  it "sets the description from the provided description if provided" do
+    needs_list = {'1' => {'active' => 'true', 'name' => 'category', 'description'  => 'test description'} }
+
+    expect(@builder).to receive(:build).with(hash_including(:name => "test description")).once
+    described_class.create_needs(@test_contact, needs_list, nil)
+  end
+
+  it "adds an 'other' need if a description is provided" do
+    needs_list = { 1 => { active: false }}
+
+    expect(@builder).to receive(:build).with(hash_including(:name => "test other description")).once
+    described_class.create_needs(@test_contact, needs_list, "test other description")
+  end
+end


### PR DESCRIPTION
This extracts the filtering logic implemented in needs_controller into a model concern, 'Filterable'.
This should be re-usable to some degree for other filterable models