### PR TITLE
Use rspec instead of rails spec in CI

### DIFF
--- a/.github/workflows/run_spec_tests.yml
+++ b/.github/workflows/run_spec_tests.yml
@@ -51,4 +51,4 @@ jobs:
         bundle exec rails db:seed
     - name: Run tests
       run: |
-        bundle exec rails spec
+        bundle exec rspec


### PR DESCRIPTION
Per #75, [this comment](https://github.com/rspec/rspec-rails/issues/208#issuecomment-413114), and [usage docs](https://github.com/rspec/rspec-rails#running-specs). With the caveat that maybe there was a reason `rails spec` was used that I'm not aware of. I defer to @rubyforbusiness 