### PR TITLE
Spike: Add jsonb column to needs and use STI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem 'csv'
 gem 'govuk_notify_rails'
 gem 'factory_bot_rails', require: false
 gem 'faker', require: false
+gem 'jsonb_accessor', '~> 1.0.0'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,10 @@ GEM
     jaro_winkler (1.5.4)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
+    jsonb_accessor (1.0.0)
+      activerecord (>= 5.0)
+      activesupport (>= 5.0)
+      pg (>= 0.18.1)
     jwt (2.2.1)
     kaminari (1.2.0)
       activesupport (>= 4.1.0)
@@ -306,6 +310,7 @@ DEPENDENCIES
   faker
   govuk_notify_rails
   jbuilder (~> 2.7)
+  jsonb_accessor (~> 1.0.0)
   kaminari
   listen (>= 3.0.5, < 3.2)
   paper_trail

--- a/app/controllers/needs_controller.rb
+++ b/app/controllers/needs_controller.rb
@@ -54,7 +54,10 @@ class NeedsController < ApplicationController
   end
 
   def need_params
-    params.require(:need).permit(:name, :status, :user_id, :category, :is_urgent)
+    params.require(:need).permit(:name, :status, :user_id, :category, :is_urgent,
+      # There's probably a better way to do this
+      :dietary_requirements, :has_oven_or_hob,
+      :has_free_prescriptions, :local_pharmacy)
   end
 
   def needs_form_params

--- a/app/models/needs/groceries_and_cooked_meals_need.rb
+++ b/app/models/needs/groceries_and_cooked_meals_need.rb
@@ -1,0 +1,5 @@
+class GroceriesAndCookedMealsNeed < Need
+  jsonb_accessor :data,
+    dietary_requirements: :string,
+    has_oven_or_hob: :boolean
+end

--- a/app/models/needs/need.rb
+++ b/app/models/needs/need.rb
@@ -4,6 +4,7 @@ require 'csv'
 
 class Need < ApplicationRecord
   include Filterable
+  self.inheritance_column = 'category'
 
   belongs_to :contact, counter_cache: true
   belongs_to :user, optional: true

--- a/app/models/needs/other_need.rb
+++ b/app/models/needs/other_need.rb
@@ -1,0 +1,2 @@
+class OtherNeed < Need
+end

--- a/app/models/needs/prescription_pickups_need.rb
+++ b/app/models/needs/prescription_pickups_need.rb
@@ -1,0 +1,5 @@
+class PrescriptionPickupsNeed < Need
+  jsonb_accessor :data,
+    has_free_prescriptions: :boolean,
+    local_pharmacy: :string
+end

--- a/app/views/needs/edit.html.erb
+++ b/app/views/needs/edit.html.erb
@@ -18,7 +18,7 @@
   <%= link_to "#{@contact.first_name}'s Needs (#{@contact.needs.count})", contact_needs_path(@contact), class: 'tabs__tab tabs__tab--current' %>
 </div>
 
-<%= form_with(model: @need, local: true) do |form| %>
+<%= form_with(model: @need.becomes(Need), local: true) do |form| %>
 
   <div class="page-header page-header--with-button">
     <h1 class="page-title"><%= @need.category.humanize %></h1>
@@ -60,6 +60,34 @@
         <strong><%= form.label :name, 'Description' %></strong>
         <span><%= form.text_area :name %></span>
       </div>
+
+      <% if @need.is_a?(GroceriesAndCookedMealsNeed) %>
+        <div class="contact-profile__row">
+          <strong><%= form.label :dietary_requirements, 'Dietary requirements' %></strong>
+          <span><%= form.text_area :dietary_requirements %></span>
+        </div>
+        <div class="contact-profile__row">
+          <strong>Oven/hob</strong>
+          <div class="checkbox">
+            <%= form.check_box :has_oven_or_hob, class: 'checkbox__input' %>
+            <%= form.label :has_oven_or_hob, 'Has an oven/hob', class: 'checkbox__label' %>
+          </div>
+        </div>
+      <% end %>
+
+      <% if @need.is_a?(PrescriptionPickupsNeed) %>
+        <div class="contact-profile__row">
+          <strong><%= form.label :local_pharmacy, 'Local pharmacy' %></strong>
+          <span><%= form.text_area :local_pharmacy %></span>
+        </div>
+        <div class="contact-profile__row">
+          <strong>Free prescriptions</strong>
+          <div class="checkbox">
+            <%= form.check_box :has_free_prescriptions, class: 'checkbox__input' %>
+            <%= form.label :has_free_prescriptions, 'Qualifies for free prescriptions', class: 'checkbox__label' %>
+          </div>
+        </div>
+      <% end %>
     </div>
   </div>
 

--- a/app/views/needs/show.html.erb
+++ b/app/views/needs/show.html.erb
@@ -54,6 +54,29 @@
       <strong>Description</strong>
       <span><%= @need.name %></span>
     </div>
+
+    <% if @need.is_a?(GroceriesAndCookedMealsNeed) %>
+      <div class="contact-profile__row">
+        <strong>Dietary requirements</strong>
+        <span><%= @need.dietary_requirements %></span>
+      </div>
+      <div class="contact-profile__row">
+        <strong>Has an oven/hob</strong>
+        <span><%= @need.has_oven_or_hob %></span>
+      </div>
+    <% end %>
+
+    <% if @need.is_a?(PrescriptionPickupsNeed) %>
+      <div class="contact-profile__row">
+        <strong>Qualifies for free prescriptions</strong>
+        <span><%= @need.has_free_prescriptions %></span>
+      </div>
+      <div class="contact-profile__row">
+        <strong>Local pharmacy</strong>
+        <span><%= @need.local_pharmacy %></span>
+      </div>
+    <% end %>
+
   </div>
   <div class="contact-profile__right">
     <div class="contact-profile__right__title">
@@ -95,7 +118,7 @@
     <% end %>
   </h2>
 
-  <%= form_with(model: [@need, @need.notes.build], local: true) do |form| %>
+  <%= form_with(model: [@need.becomes(Need), @need.notes.build], local: true) do |form| %>
     <div class="field">
       <%= form.label :body, 'Add a note', class: "field__label" %>
       <%= form.text_area :body, class: 'note-textarea' %>

--- a/app/views/shared/_needs_table.html.erb
+++ b/app/views/shared/_needs_table.html.erb
@@ -53,7 +53,7 @@
           <td>Unassigned</td>
         <% end %>
         <td><%= link_to(need.contact_name, contact_path(need.contact.id)) %></td>
-        <td><strong><%= link_to need.name, need %></strong></td>
+        <td><strong><%= link_to need.name, need_path(need) %></strong></td>
         <td><%= status(need.completed_on) %></td>
         <td>
           <% if need.contact_is_vulnerable %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,8 @@ module IHaveINeed
     # <%= Rails.configuration.councils[ENV['COUNCIL']]['support_email'] %>
     config.councils = config_for(:councils)
 
+    config.autoload_paths += %W(#{Rails.root}/app/models/needs)
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/db/migrate/20200407183237_add_data_to_needs.rb
+++ b/db/migrate/20200407183237_add_data_to_needs.rb
@@ -1,0 +1,5 @@
+class AddDataToNeeds < ActiveRecord::Migration[6.0]
+  def change
+    add_column :needs, :data, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_03_095904) do
+ActiveRecord::Schema.define(version: 2020_04_07_183237) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -61,6 +61,7 @@ ActiveRecord::Schema.define(version: 2020_04_03_095904) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "category"
     t.boolean "is_urgent", default: false
+    t.jsonb "data"
     t.index ["contact_id"], name: "index_needs_on_contact_id"
     t.index ["user_id"], name: "index_needs_on_user_id"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -22,8 +22,7 @@ ActiveRecord::Base.transaction do
 
       contacts = FactoryBot.create_list :contact, 50, contact_list: contact_list
 
-      need_categories = ['phone triage', 'groceries and cooked meals', 'physical and mental wellbeing', 'financial support',
-                        'staying social', 'prescription pickups', 'book drops and entertainment', 'dog walking', 'other']
+      need_categories = ['PrescriptionPickupsNeed', 'GroceriesAndCookedMealsNeed', 'OtherNeed']
 
       contacts.first(10).each do |contact|
         [1, 2, 3].sample.times do


### PR DESCRIPTION
This is just exploratory, and one of several approaches we'll discuss tomorrow, not necessarily the best one. I was just curious what it could look like, and I'm sure it could be approved if we even decide to go this direction.

This PR adds a jsonb column to the needs table and uses Single Table Inheritance  to handle the need types having their own fields. This does mean hardcoding the need types rather than letting them be dynamic, although we were already doing that to an extent, just as a list rather than as models.

Note that if you want to run this, you'll probably need to comment out the three `Logger` lines in config/environment/development.rb until #83 is resolved.

<img width="1240" alt="Screenshot 2020-04-07 at 20 31 54" src="https://user-images.githubusercontent.com/761444/78711464-ee231100-790e-11ea-93c5-05810cb22634.png">
<img width="1231" alt="Screenshot 2020-04-07 at 20 32 03" src="https://user-images.githubusercontent.com/761444/78711467-eebba780-790e-11ea-9a82-81c3c55718e2.png">
<img width="1189" alt="Screenshot 2020-04-07 at 20 32 15" src="https://user-images.githubusercontent.com/761444/78711469-ef543e00-790e-11ea-8f9a-4e77b2b43ce3.png">
<img width="1202" alt="Screenshot 2020-04-07 at 20 32 23" src="https://user-images.githubusercontent.com/761444/78711473-efecd480-790e-11ea-9e60-4aff1a3edd41.png">
