### PR TITLE
Remove wrong flash sign in message

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -43,6 +43,6 @@ class ApplicationController < ActionController::Base
     return if current_user
 
     save_passwordless_redirect_location!(User)
-    redirect_to auth.sign_in_path, flash: { error: 'Please sign in' }
+    redirect_to auth.sign_in_path
   end
 end


### PR DESCRIPTION
**Background**
We are using login and after logging in, there's a flash that says "Please sign in" which is wrong.

**Aim**
Remove wrong flash that says "Please sign in" after login.

**Implementation**
Remove the `flash` in `redirect_to`.

**TIL**
We are using `passwordless` gem to create and manipulate the magic link.
In gem [example](https://github.com/mikker/passwordless#getting-the-current-user-restricting-access-the-usual) we see:
```
redirect_to root_path, flash: { error: 'You are not worthy!' }
```
In this case we will `flash` message in all cases, whether we were successful with the authentication or not. 
Actually if using wrong link we will `raise` exception. Example `/sign_in/wrong_link`.
But if we are not sign in and try `/contacts` we will be redirected to `/sign_in` with `flash` message.

`passwordless` gem templates are `app/views/passwordless/sessions/create.html.erb` and `app/views/passwordless/sessions/new.html.erb` and we do not use `flash` inside them. This is why there is no need of `flash` message.

But we are working with `flash` message in `app/views/layouts/application.html.erb` which show the `flash` message and create the issue.
