### PR TITLE
Prevented filters section horizontal overflow

### DIFF
--- a/app/assets/stylesheets/filters.scss
+++ b/app/assets/stylesheets/filters.scss
@@ -3,6 +3,7 @@
 .filters{
     display: flex;
     flex-direction: row;
+    flex: 1 0 auto;
     // .filters__controls{}
     .filters__content{
         display: flex;


### PR DESCRIPTION
Background:
https://trello.com/c/SleQd7i2/295-fix-styling-of-filters-on-narrower-screens

Solution:
- Supported flex container growing thus preventing horizontal overflow