### PR TITLE
Improve styling of note category control and display

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -20,6 +20,14 @@
         grid-template-columns: 1fr 1fr;
         grid-column-gap: 35px;
     }
+  &.field-section--four-cols{
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr 1fr;
+    grid-column-gap: 35px;
+    legend {
+      margin-bottom: 20px;
+    }
+  }
     .field:last-child{
         margin-bottom: 0px;
     }

--- a/app/views/needs/_notes.html.erb
+++ b/app/views/needs/_notes.html.erb
@@ -2,8 +2,10 @@
   
   <%= form_with(model: [@need, @need.notes.build], local: true, class: "notes__form") do |form| %>
     <h3 class="notes__title">Updates</h3>
-    <div class="field">
-      <%= form.label :category, 'Choose a category', class: "field__label" %>
+    <fieldset class="field-section field-section--four-cols">
+      <legend>
+        <%= form.label :category, 'Choose a category', class: "field__label" %>
+      </legend>
       <% Note.categories_without_phone_import.each.with_index do |nc, index| %>
         <div class="radio">
           <% field_value = "category_#{note_category_form_id(nc)}"  %>
@@ -11,7 +13,7 @@
           <label for=<%= field_value %> class="radio__label"><%= note_category_form_display(nc) %></label>
         </div>
       <% end %>
-    </div>
+    </fieldset>
     <%= form.label :body, 'Add a note', class: "visually-hidden" %>
     <%= form.text_field :body, class: "notes__field", placeholder: "Add a note" %>
     <%= form.submit "Add update", class: "button notes__button" %>
@@ -23,7 +25,7 @@
       <% next if note == @need.notes.last %>
         <article class="note">
           <header class="note__header">
-            <%= note.category %>
+            <strong><%= note.category %></strong>
             <time datetime="<%= note.created_at %>" title="<%= note.created_at %>">
               <%= time_ago_in_words(note.created_at).humanize %> ago 
             </time>
@@ -36,5 +38,5 @@
       <% end %>
     </div>
   <% end %>
-
 </section>
+


### PR DESCRIPTION
Background:
https://trello.com/c/d9DEFBuW/290-improve-styling-of-note-category-control-and-display

Solution:
- Arranged radio buttons horizontally in a grid row
- Made the node type bold