### PR TITLE
Feature/284 add e2e tests for updating a need

### DIFF
--- a/.github/workflows/run_cucumber_tests.yml
+++ b/.github/workflows/run_cucumber_tests.yml
@@ -3,7 +3,7 @@ name: Ruby Cucumber Tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, feature/284-add-e2e-tests-for-updating-a-need-experiment-firefox-github ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/run_cucumber_tests.yml
+++ b/.github/workflows/run_cucumber_tests.yml
@@ -26,6 +26,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Install firefox
+      run: apt install firefox
     - name: Set up Ruby 2.5.7
       uses: actions/setup-ruby@v1
       with:

--- a/.github/workflows/run_cucumber_tests.yml
+++ b/.github/workflows/run_cucumber_tests.yml
@@ -26,8 +26,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Install firefox
-      run: sudo apt-get install -y firefox
     - name: Set up Ruby 2.5.7
       uses: actions/setup-ruby@v1
       with:

--- a/.github/workflows/run_cucumber_tests.yml
+++ b/.github/workflows/run_cucumber_tests.yml
@@ -3,7 +3,7 @@ name: Ruby Cucumber Tests
 
 on:
   push:
-    branches: [ master, feature/284-add-e2e-tests-for-updating-a-need-experiment-firefox-github ]
+    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/run_cucumber_tests.yml
+++ b/.github/workflows/run_cucumber_tests.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install firefox
-      run: apt install firefox
+      run: sudo apt-get install -y firefox
     - name: Set up Ruby 2.5.7
       uses: actions/setup-ruby@v1
       with:

--- a/features/edit_need.feature
+++ b/features/edit_need.feature
@@ -8,22 +8,20 @@ Feature: Add needs
 
   Scenario: Assign myself a need
     Given a resident with a need exists
-    And I am viewing the need
     When I assign the need to me
     Then I see the need in the 'assigned to me' page
     And I see the updated need details in the contact's 'needs' list
-#
-#  Scenario: Reassign a need from myself to another user
-#    Given a resident with a need exists
-#    And I am viewing the need
-#    And the need is assigned to me
-#    When I assign the need to another user
-#    Then I no longer see the need in the 'assigned to me' page
-#    And I see the updated need details in the contact's needs list
-#
-#  Scenario:
-#    Given a resident with a need exists
-#    And I am viewing the need
-#    And the need has status 'to do'
-#    When I change the need status to 'complete'
-#    Then I see the updated need details in the contact's needs list
+
+  Scenario: Reassign a need from myself to another user
+    Given a resident with a need exists
+    And I have assigned the need to me
+    When I assign the need to another user
+    Then I no longer see the need in the 'assigned to me' page
+    And I see the updated need details in the contact's 'needs' list
+
+  Scenario:
+    Given a resident with a need exists
+    And I have assigned the need to me
+    And the need has status 'to do'
+    When I change the need status to 'complete'
+    Then I see the updated need details in the contact's 'completed' list

--- a/features/edit_need.feature
+++ b/features/edit_need.feature
@@ -6,7 +6,7 @@ Feature: Edit needs
   Background:
     * I am logged into the system
 
-  @javascript @assign-me
+  @javascript
   Scenario: Assign myself a need
     Given a resident with a need exists
     When I assign the need to me

--- a/features/edit_need.feature
+++ b/features/edit_need.feature
@@ -6,12 +6,14 @@ Feature: Add needs
   Background:
     * I am logged into the system
 
+  @javascript
   Scenario: Assign myself a need
     Given a resident with a need exists
     When I assign the need to me
     Then I see the need in the 'assigned to me' page
     And I see the updated need details in the contact's 'needs' list
 
+  @javascript
   Scenario: Reassign a need from myself to another user
     Given a resident with a need exists
     And I have assigned the need to me
@@ -19,6 +21,7 @@ Feature: Add needs
     Then I no longer see the need in the 'assigned to me' page
     And I see the updated need details in the contact's 'needs' list
 
+  @javascript
   Scenario:
     Given a resident with a need exists
     And I have assigned the need to me

--- a/features/edit_need.feature
+++ b/features/edit_need.feature
@@ -1,0 +1,29 @@
+Feature: Add needs
+  As a user of the system
+  I want to edit a persons need
+  So that I can assign a user, and change the key details
+
+  Background:
+    * I am logged into the system
+
+  Scenario: Assign myself a need
+    Given a resident with a need exists
+    And I am viewing the need
+    When I assign the need to me
+    Then I see the need in the 'assigned to me' page
+    And I see the updated need details in the contact's 'needs' list
+#
+#  Scenario: Reassign a need from myself to another user
+#    Given a resident with a need exists
+#    And I am viewing the need
+#    And the need is assigned to me
+#    When I assign the need to another user
+#    Then I no longer see the need in the 'assigned to me' page
+#    And I see the updated need details in the contact's needs list
+#
+#  Scenario:
+#    Given a resident with a need exists
+#    And I am viewing the need
+#    And the need has status 'to do'
+#    When I change the need status to 'complete'
+#    Then I see the updated need details in the contact's needs list

--- a/features/edit_need.feature
+++ b/features/edit_need.feature
@@ -1,4 +1,4 @@
-Feature: Add needs
+Feature: Edit needs
   As a user of the system
   I want to edit a persons need
   So that I can assign a user, and change the key details
@@ -6,7 +6,7 @@ Feature: Add needs
   Background:
     * I am logged into the system
 
-  @javascript
+  @javascript @assign-me
   Scenario: Assign myself a need
     Given a resident with a need exists
     When I assign the need to me

--- a/features/step_definitions/authentication_steps.rb
+++ b/features/step_definitions/authentication_steps.rb
@@ -15,6 +15,7 @@ def generate_magic_link(admin = false)
   tester = User.create!(email: email,
                         invited: Date.today,
                         admin: admin)
+  @user = tester
   session = Passwordless::Session.new({
                                         authenticatable: tester,
                                         user_agent: 'Cucumber-tests',

--- a/features/step_definitions/edit_need_steps.rb
+++ b/features/step_definitions/edit_need_steps.rb
@@ -4,20 +4,20 @@ Given('a resident with a need exists') do
 end
 
 When('I (assign)/(have assigned) the need to me') do
-  visit "needs/#{@need.id}"
+  visit "/needs/#{@need.id}"
   page.select 'admin@test.com', from: 'need_user_id'
   @expected_assignee = 'admin@test.com'
 end
 
 When('I assign the need to another user') do
   @another_user = User.create!(email: 'other_user@email.com', invited: Date.today)
-  visit "needs/#{@need.id}"
+  visit "/needs/#{@need.id}"
   page.select 'other_user@email.com', from: 'need_user_id'
   @expected_assignee = 'other_user@email.com'
 end
 
 When("I change the need status to 'complete'") do
-  visit "needs/#{@need.id}"
+  visit "/needs/#{@need.id}"
   page.select 'Complete', from: 'need_status'
 end
 

--- a/features/step_definitions/edit_need_steps.rb
+++ b/features/step_definitions/edit_need_steps.rb
@@ -7,6 +7,7 @@ When('I (assign)/(have assigned) the need to me') do
   visit "/needs/#{@need.id}"
   page.select 'admin@test.com', from: 'need_user_id'
   @expected_assignee = 'admin@test.com'
+  page.find('.alert', text: 'Need was successfully updated.')
 end
 
 When('I assign the need to another user') do
@@ -14,11 +15,13 @@ When('I assign the need to another user') do
   visit "/needs/#{@need.id}"
   page.select 'other_user@email.com', from: 'need_user_id'
   @expected_assignee = 'other_user@email.com'
+  page.find('.alert', text: 'Need was successfully updated.')
 end
 
 When("I change the need status to 'complete'") do
   visit "/needs/#{@need.id}"
   page.select 'Complete', from: 'need_status'
+  page.find('.alert', text: 'Need was successfully updated.')
 end
 
 And("the need has status 'to do'") do

--- a/features/step_definitions/edit_need_steps.rb
+++ b/features/step_definitions/edit_need_steps.rb
@@ -3,28 +3,26 @@ Given('a resident with a need exists') do
   @need = Need.create!(contact_id: @contact.id, name: 'Phone Triage', category: 'Phone Triage')
 end
 
-When('I am viewing the need') do
+When('I (assign)/(have assigned) the need to me') do
   visit "needs/#{@need.id}"
-end
-
-When('I assign the need to me') do
   page.select 'admin@test.com', from: 'need_user_id'
+  @expected_assignee = 'admin@test.com'
 end
 
 When('I assign the need to another user') do
-  pending
+  @another_user = User.create!(email: 'other_user@email.com', invited: Date.today)
+  visit "needs/#{@need.id}"
+  page.select 'other_user@email.com', from: 'need_user_id'
+  @expected_assignee = 'other_user@email.com'
 end
 
 When("I change the need status to 'complete'") do
-  pending
-end
-
-And('the need is assigned to me') do
-  pending
+  visit "needs/#{@need.id}"
+  page.select 'Complete', from: 'need_status'
 end
 
 And("the need has status 'to do'") do
-  pending
+  # need is incomplete by default
 end
 
 Then("I see the need in the 'assigned to me' page") do
@@ -34,22 +32,24 @@ Then("I see the need in the 'assigned to me' page") do
   expect(assignee_column).to have_content 'admin@test.com'
 end
 
+Then("I no longer see the need in the 'assigned to me' page") do
+  visit '/?user_id=1'
+  content_panel = find('div.panel')
+  expect(content_panel).to have_content 'No matches'
+end
+
 And("I see the updated need details in the contact's {string} list") do |area|
   visit "/contacts/#{@contact.id}"
   need_row = get_area_panel(area).find('tbody tr')
   assignee_column = need_row.find('td:nth-child(3)')
-  expect(assignee_column).to have_content 'admin@test.com'
-end
-
-Then("I no longer see the need in the 'assigned to me' page") do
-  pending
+  expect(assignee_column).to have_content @expected_assignee
 end
 
 def get_area_panel(area)
   case area
   when 'needs'
     panel_selector = '.with-left-sidebar__right .panel.panel--unpadded:nth-of-type(1)'
-  when 'to do'
+  when 'completed'
     panel_selector = '.with-left-sidebar__right .panel.panel--unpadded:nth-of-type(2)'
   else
     raise "Cannot look for non-existent panel #{area}"

--- a/features/step_definitions/edit_need_steps.rb
+++ b/features/step_definitions/edit_need_steps.rb
@@ -29,14 +29,14 @@ And("the need has status 'to do'") do
 end
 
 Then("I see the need in the 'assigned to me' page") do
-  visit '/?user_id=1'
+  visit "/?user_id=#{@user.id}"
   table_row = find('tbody tr')
   assignee_column = table_row.find('td:nth-child(7)')
   expect(assignee_column).to have_content 'admin@test.com'
 end
 
 Then("I no longer see the need in the 'assigned to me' page") do
-  visit '/?user_id=1'
+  visit "/?user_id=#{@user.id}"
   content_panel = find('div.panel')
   expect(content_panel).to have_content 'No matches'
 end

--- a/features/step_definitions/edit_need_steps.rb
+++ b/features/step_definitions/edit_need_steps.rb
@@ -1,0 +1,58 @@
+Given('a resident with a need exists') do
+  @contact = Contact.create!(first_name: 'Test')
+  @need = Need.create!(contact_id: @contact.id, name: 'Phone Triage', category: 'Phone Triage')
+end
+
+When('I am viewing the need') do
+  visit "needs/#{@need.id}"
+end
+
+When('I assign the need to me') do
+  page.select 'admin@test.com', from: 'need_user_id'
+end
+
+When('I assign the need to another user') do
+  pending
+end
+
+When("I change the need status to 'complete'") do
+  pending
+end
+
+And('the need is assigned to me') do
+  pending
+end
+
+And("the need has status 'to do'") do
+  pending
+end
+
+Then("I see the need in the 'assigned to me' page") do
+  visit '/?user_id=1'
+  table_row = find('tbody tr')
+  assignee_column = table_row.find('td:nth-child(7)')
+  expect(assignee_column).to have_content 'admin@test.com'
+end
+
+And("I see the updated need details in the contact's {string} list") do |area|
+  visit "/contacts/#{@contact.id}"
+  need_row = get_area_panel(area).find('tbody tr')
+  assignee_column = need_row.find('td:nth-child(3)')
+  expect(assignee_column).to have_content 'admin@test.com'
+end
+
+Then("I no longer see the need in the 'assigned to me' page") do
+  pending
+end
+
+def get_area_panel(area)
+  case area
+  when 'needs'
+    panel_selector = '.with-left-sidebar__right .panel.panel--unpadded:nth-of-type(1)'
+  when 'to do'
+    panel_selector = '.with-left-sidebar__right .panel.panel--unpadded:nth-of-type(2)'
+  else
+    raise "Cannot look for non-existent panel #{area}"
+  end
+  page.find(panel_selector)
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -70,12 +70,12 @@ Capybara.register_driver :remote_chrome do |app|
 end
 
 Capybara.register_driver :selenium do |app|
-  browser_options = Selenium::WebDriver::Firefox::Options.new()
+  browser_options = Selenium::WebDriver::Firefox::Options.new
   browser_options.args << '--headless'
   Capybara::Selenium::Driver.new(
-      app,
-      browser: :firefox,
-      options: browser_options
+    app,
+    browser: :firefox,
+    options: browser_options
   )
 end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -69,6 +69,16 @@ Capybara.register_driver :remote_chrome do |app|
   Capybara::Selenium::Driver.new(app, browser: :chrome, url: 'http://localhost:9515', desired_capabilities: capabilities)
 end
 
+Capybara.register_driver :selenium do |app|
+  browser_options = Selenium::WebDriver::Firefox::Options.new()
+  browser_options.args << '--headless'
+  Capybara::Selenium::Driver.new(
+      app,
+      browser: :firefox,
+      options: browser_options
+  )
+end
+
 if ENV['BROWSER']
   DatabaseCleaner.strategy = :truncation
   Capybara.default_driver = ENV['BROWSER'].to_sym


### PR DESCRIPTION
Add acceptance tests to cover editing a need (changing status, assignee)
Allow running javascript dependent tests only in headless firefox