### PR TITLE
IE11 accordion expansion/closing doesn't work

### DIFF
--- a/app/assets/stylesheets/accordion.scss
+++ b/app/assets/stylesheets/accordion.scss
@@ -1,6 +1,11 @@
 @import "variables";
 
 .accordion{
+    div {
+      .accordion__content {
+        cursor: pointer;
+      }
+    }
     .accordion__control{
         background: $text;
         border: none;

--- a/app/javascript/packs/accordion.js
+++ b/app/javascript/packs/accordion.js
@@ -1,6 +1,6 @@
 const accordion = document.querySelector(".accordion")
 
-let controls = accordion.querySelectorAll(".accordion__control")
+let controls = Array.prototype.slice.call(accordion.querySelectorAll(".accordion__control"), 0)
 let contents = accordion.querySelectorAll(".accordion__content")
 
 controls.forEach((control, i) => control.addEventListener("click", e  => {

--- a/app/views/shared/_profile-accordion.html.erb
+++ b/app/views/shared/_profile-accordion.html.erb
@@ -31,10 +31,10 @@
         <%= link_to "Edit", edit_contact_path(@contact), class: "accordion__edit-link" %>
     </div>
 
-    <button class="accordion__control" aria-expanded="false">
+    <button class="accordion__control" aria-expanded="true">
         <h2 class="accordion__title">Household</h2>  
     </button>
-    <div hidden class="accordion__content">  
+    <div class="accordion__content">
         <dl class="details-list">
             <dt class="details-list__caption">Number of people living there</dt>
             <dd class="details-list__value"><%= dash_if_empty @contact.count_people_in_house %></dd>
@@ -44,20 +44,20 @@
         </dl>
     </div>
 
-    <button class="accordion__control" aria-expanded="false">
+    <button class="accordion__control" aria-expanded="true">
         <h2 class="accordion__title">Delivery requirements</h2>  
     </button>
-    <div hidden class="accordion__content">  
+    <div class="accordion__content">
         <dl class="details-list">
             <dt class="details-list__caption">Any special delivery details</dt>
             <dd class="details-list__value"><%= dash_if_empty @contact.delivery_details %></dd>
         </dl>
     </div>
 
-    <button class="accordion__control" aria-expanded="false">
+    <button class="accordion__control" aria-expanded="true">
         <h2 class="accordion__title">Linked records</h2>  
     </button>
-    <div hidden class="accordion__content">  
+    <div class="accordion__content">
         <dl class="details-list">
             <dt class="details-list__caption">Mosaic ID</dt>
             <dd class="details-list__value"><%= dash_if_empty @contact.mosaic_id %></dd>
@@ -67,10 +67,10 @@
         </dl>
     </div>
 
-    <button class="accordion__control" aria-expanded="false">
+    <button class="accordion__control" aria-expanded="true">
         <h2 class="accordion__title">Additional information</h2>  
     </button>
-    <div hidden class="accordion__content">  
+    <div class="accordion__content">
         <dl class="details-list">
             <dt class="details-list__caption">Dietary requirements</dt>
             <dd class="details-list__value">


### PR DESCRIPTION
Background:
https://trello.com/c/Js7GZBxK/307-ie-11-bug-accordions-not-closing

Solution:
- As it turned out, IE11 **doesn't support forEach** method on NodeList, which is retuend by **querySelectorAll**. Converting the NodeList to Array solves the problem.
- Expanded all accordions when loading the contacts view