### PR TITLE
Add supplemental fields to food need

### DIFF
--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -12,6 +12,13 @@ class Need < ApplicationRecord
 
   has_paper_trail
 
+  jsonb_accessor :supplemental_data,
+                 food_priority: :string,
+                 food_service_type: :string
+
+  # validates :food_priority, inclusion: { in: %w[1 2 3] }, allow_blank: true
+  # validates :food_service_type, inclusion: { in: ['Hot meal', 'Heat up', 'Grocery delivery'] }, allow_blank: true
+
   scope :completed, -> { where.not(completed_on: nil) }
   scope :uncompleted, -> { where(completed_on: nil) }
   scope :filter_by_category, ->(category) { where(category: category.downcase) }

--- a/app/services/needs_creator.rb
+++ b/app/services/needs_creator.rb
@@ -24,6 +24,10 @@ class NeedsCreator
                          need_values['description']
                        end
     need_hash[:is_urgent] = need_values['is_urgent']
+
+    need_hash[:food_priority] = need_values['food_priority'] if need_values['food_priority'].present?
+    need_hash[:food_service_type] = need_values['food_service_type'] if need_values['food_service_type'].present?
+
     need_hash
   end
 end

--- a/app/views/needs/show.html.erb
+++ b/app/views/needs/show.html.erb
@@ -33,6 +33,16 @@
           <dt class="details-list__caption">Description</dt>
           <dd class="details-list__value"><%= @need.name %></dd>
 
+          <% if @need.food_priority %>
+            <dt class="details-list__caption">Food requirements priority</dt>
+            <dd class="details-list__value">Priority <%= @need.food_priority %></dt>
+          <% end %>
+
+          <% if @need.food_service_type %>
+            <dt class="details-list__caption">Food service type</dt>
+            <dd class="details-list__value"><%= @need.food_service_type %></dt>
+          <% end %>
+
           <dt class="details-list__caption">Created</dt>
           <dd class="details-list__value"><%= @need.created_at&.strftime("%-d %B %Y") %></dd>
         </dl>

--- a/app/views/triage/_groceries_and_cooked_meals.html.erb
+++ b/app/views/triage/_groceries_and_cooked_meals.html.erb
@@ -1,23 +1,45 @@
 <fieldset class="field-section field-section--two-cols">
-  <legend><h3 class="field-section__title">Any dietary requirements?</h3></legend>
+  <legend><h3 class="field-section__title">Food requirements priority</h3></legend>
 
   <div class="radio">
-    <%= form.radio_button :any_dietary_requirements, true, :id => "any_dietary_requirements_true" %>
-    <label for="any_dietary_requirements_true" class="radio__label">Yes</label>
+    <%= need_form.radio_button "needs_list[#{need_index}][food_priority]", '1', :id => "needs_food_priority_#{need_index}_1" %>
+    <label for="needs_food_priority_<%= need_index %>_1" class="radio__label">Priority 1</label>
   </div>
   <div class="radio">
-    <%= form.radio_button :any_dietary_requirements, false, :id => "any_dietary_requirements_false" %>
-    <label for="any_dietary_requirements_false" class="radio__label">No</label>
+    <%= need_form.radio_button "needs_list[#{need_index}][food_priority]", '2', :id => "needs_food_priority_#{need_index}_2" %>
+    <label for="needs_food_priority_<%= need_index %>_2" class="radio__label">Priority 2</label>
+  </div>
+  <div class="radio">
+    <%= need_form.radio_button "needs_list[#{need_index}][food_priority]", '3', :id => "needs_food_priority_#{need_index}_3" %>
+    <label for="needs_food_priority_<%= need_index %>_3" class="radio__label">Priority 3</label>
+  </div>
+
+</fieldset>
+
+<fieldset class="field-section field-section--two-cols">
+  <legend><h3 class="field-section__title">Which type of food service?</h3></legend>
+
+  <div class="radio">
+    <%= need_form.radio_button "needs_list[#{need_index}][food_service_type]", 'Hot meal', :id => "needs_food_service_type_#{need_index}_hot_meal" %>
+    <label for="needs_food_service_type_<%= need_index %>_hot_meal" class="radio__label">Hot meal</label>
+  </div>
+  <div class="radio">
+    <%= need_form.radio_button "needs_list[#{need_index}][food_service_type]", 'Heat up', :id => "needs_food_service_type_#{need_index}_heat_up" %>
+    <label for="needs_food_service_type_<%= need_index %>_heat_up" class="radio__label">Heat up</label>
+  </div>
+  <div class="radio">
+    <%= need_form.radio_button "needs_list[#{need_index}][food_service_type]", 'Grocery delivery', :id => "needs_food_service_type_#{need_index}_grocery_delivery" %>
+    <label for="needs_food_service_type_<%= need_index %>_grocery_delivery" class="radio__label">Grocery delivery</label>
   </div>
 
 </fieldset>
 
 <div class="field field--span-two-cols">
-  <%= form.label :dietary_details, class: "field__label" %>
+  <%= form.label :dietary_details, "Any dietary requirements?", class: "field__label" %>
   <%= form.text_area :dietary_details %>
 </div>
 
-  <div class="field field--span-two-cols">
+<div class="field field--span-two-cols">
   <%= form.label :cooking_facilities, "What cooking facilities do they have?", class: "field__label" %>
   <%= form.text_area :cooking_facilities %>
 </div>

--- a/db/migrate/20200415112940_add_supplemental_data_to_needs.rb
+++ b/db/migrate/20200415112940_add_supplemental_data_to_needs.rb
@@ -1,0 +1,5 @@
+class AddSupplementalDataToNeeds < ActiveRecord::Migration[6.0]
+  def change
+    add_column :needs, :supplemental_data, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_15_101248) do
+ActiveRecord::Schema.define(version: 2020_04_15_112940) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -70,6 +70,7 @@ ActiveRecord::Schema.define(version: 2020_04_15_101248) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "category"
     t.boolean "is_urgent", default: false
+    t.jsonb "supplemental_data"
     t.datetime "start_on"
     t.index ["contact_id"], name: "index_needs_on_contact_id"
     t.index ["user_id"], name: "index_needs_on_user_id"


### PR DESCRIPTION
**Note: This PR is meant to be merged into @jamiebuckley's branch**

This commit also consolidates the two dietary requirements questions. I've added validation for the two new need fields, but commented it out until we get validation working in the triage controller.

<img width="803" alt="Screenshot 2020-04-15 at 13 38 07" src="https://user-images.githubusercontent.com/761444/79337955-5f218480-7f1e-11ea-9646-52427dd40d91.png">
<img width="599" alt="Screenshot 2020-04-15 at 13 38 00" src="https://user-images.githubusercontent.com/761444/79337957-5fba1b00-7f1e-11ea-9fe9-1e30102ce167.png">
