### PR TITLE
Radio buttons not properly aligned

### DIFF
--- a/app/views/contacts/_extra_questions.html.erb
+++ b/app/views/contacts/_extra_questions.html.erb
@@ -14,7 +14,6 @@
 
 <fieldset class="field-section field-section--two-cols">
   <legend><h2 class="field-section__title">Any children under 15?</h2></legend>
-  <br/>
   <div class="radio">
     <%= form.radio_button :any_children_below_15, true, :id => "any_children_below_15_true" %>
     <label for="any_children_below_15_true" class="radio__label">Yes</label>
@@ -27,7 +26,6 @@
 
 <fieldset class="field-section field-section--two-cols">
   <legend><h2 class="field-section__title">Are you or anyone in your home showing any symptoms of COVID-19?</h2></legend>
-  <br/>
   <div class="radio">
     <%= form.radio_button :has_covid_symptoms, true, :id => "has_covid_symptoms_true" %>
     <label for="has_covid_symptoms_true" class="radio__label">Yes</label>


### PR DESCRIPTION
Background:
https://trello.com/c/mnaH4m1Q/318-radio-buttons-not-properly-aligned

Solution:
- Removed extra <br /> tags which caused the radio button divs to be placed on separate lines