### PR TITLE
Remove validation from count_people_in_house

### DIFF
--- a/app/views/contacts/_extra_questions.html.erb
+++ b/app/views/contacts/_extra_questions.html.erb
@@ -3,7 +3,7 @@
 
   <div class="field field">
     <%= form.label :count_people_in_house, 'How many people in total live there?', class: "field__label" %>
-    <%= form.number_field :count_people_in_house, min: "1" %>
+    <%= form.number_field :count_people_in_house %>
   </div>
 
   <div class="field field--span-two-cols">


### PR DESCRIPTION
I expect managers may be filling out this form without always having this infromation to hand. This validation made it so you can't submit the form without a number.