### PR TITLE
Hide future needs on needs index

### DIFF
--- a/app/controllers/needs_controller.rb
+++ b/app/controllers/needs_controller.rb
@@ -10,7 +10,8 @@ class NeedsController < ApplicationController
   def index
     @params = params.permit(:user_id, :status, :category, :page, :order_dir, :order, :commit, :is_urgent)
     @users = User.all
-    @needs = Need.filter_and_sort(@params.slice(:category, :user_id, :status, :is_urgent), @params.slice(:order, :order_dir))
+    @needs = Need.started
+    @needs = @needs.filter_and_sort(@params.slice(:category, :user_id, :status, :is_urgent), @params.slice(:order, :order_dir))
     @needs = @needs.page(params[:page]) unless request.format == 'csv'
     respond_to do |format|
       format.html

--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -21,6 +21,7 @@ class Need < ApplicationRecord
 
   scope :completed, -> { where.not(completed_on: nil) }
   scope :uncompleted, -> { where(completed_on: nil) }
+  scope :started, -> { where('start_on IS NULL or start_on <= ?', Date.today) }
   scope :filter_by_category, ->(category) { where(category: category.downcase) }
 
   scope :filter_by_user_id, lambda { |user_id|

--- a/features/list_needs.feature
+++ b/features/list_needs.feature
@@ -7,7 +7,10 @@ Feature: List needs
     * I am logged into the system
 
   Scenario: View last contacted date
-    Given a unique resident with a "Phone triage" need
+    Given a unique resident
+    When I add needs "Phone triage"
+    And I set the start date for the "Phone triage" need to "1/1/2020"
+    And I submit the add needs form
     And I add a "Successful Call" note "Phone call text"
     And I submit the form to create the note
     When I view any needs list row for that resident

--- a/features/step_definitions/need_steps.rb
+++ b/features/step_definitions/need_steps.rb
@@ -11,26 +11,35 @@ end
 When('I add needs {string}') do |need|
   visit "contacts/#{@contact.id}"
   click_link 'Triage'
-  choose_yes_selected_id_from(need)
+  choose_yes_on_need(page, need)
+end
+
+And('I set the start date for the {string} need to {string}') do |need, start_date|
+  need_block = find_need_block(page, need)
+  start_date_fieldset = find_fieldset(need_block, /scheduled/)
+  start_date_fieldset.find('input').fill_in(with: start_date)
 end
 
 And('I add another need {string}') do |need|
-  choose_yes_selected_id_from(need)
+  choose_yes_on_need(page, need)
 end
 
 And('I submit the add needs form') do
   click_button('Save changes')
 end
 
-def choose_yes_selected_id_from(need)
-  yes_needs = { phone_triage: 'needs_active_0_true',
-                groceries_and_cooked_meals: 'needs_active_1_true',
-                physical_and_mental_wellbeing: 'needs_active_2_true',
-                financial_support: 'needs_active_3_true',
-                staying_social: 'needs_active_4_true',
-                prescription_pickups: 'needs_active_5_true',
-                book_drops_and_entertainment: 'needs_active_6_true',
-                dog_walking: 'needs_active_7_true' }
-  radio_id = yes_needs.fetch(need.downcase.gsub(' ', '_').to_sym)
-  page.find("label[for=#{radio_id}]").click
+def choose_yes_on_need(element, need)
+  need_block = find_need_block(element, need)
+  radio_fieldset = find_fieldset(need_block, 'Is this needed?')
+  radio_fieldset.find('label', text: 'Yes').click
+end
+
+def find_need_block(element, title_text)
+  element.find('.triage-grid__title', text: title_text)
+         .ancestor('.triage-grid__need')
+end
+
+def find_fieldset(element, legend_text)
+  element.find('legend', text: legend_text)
+         .ancestor('fieldset')
 end

--- a/features/step_definitions/needs_list_steps.rb
+++ b/features/step_definitions/needs_list_steps.rb
@@ -1,9 +1,3 @@
-Given('a unique resident with a {string} need') do |need|
-  @contact = Contact.create!(first_name: 'Test' + rand(10**10).to_s(36))
-  step "I add needs \"#{need}\""
-  step 'I submit the add needs form'
-end
-
 When('I view any needs list row for that resident') do
   visit '/'
   @resident_row = find_resident_row(@contact.first_name)

--- a/features/step_definitions/person_steps.rb
+++ b/features/step_definitions/person_steps.rb
@@ -2,6 +2,10 @@ Given(/^a resident$/) do
   @contact = Contact.create!(first_name: 'Test')
 end
 
+Given(/^a unique resident$/) do
+  @contact = Contact.create!(first_name: 'Test' + rand(10**10).to_s(36))
+end
+
 When(/^I edit the residents name$/) do
   visit "contacts/#{@contact.id}"
   click_link 'Edit'

--- a/spec/controllers/needs_controller_spec.rb
+++ b/spec/controllers/needs_controller_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe NeedsController, type: :controller do
     need = class_double('Need').as_stubbed_const
     allow(need).to receive(:filter_and_sort).and_return(need)
     allow(need).to receive(:page).and_return(need)
+    allow(need).to receive(:started).and_return(need)
     need
   end
 


### PR DESCRIPTION
Prior to this, the needs index showed needs that hadn't started yet, and didn't differentiate them. Ideally we'd indicate it in a column and enable filtering on it, but that's quite complex. This is a short-term fix. You can still view future needs on the person page.