### PR TITLE
Fixed IE 11 select boxes and placeholder styling conerns

### DIFF
--- a/app/assets/stylesheets/_globals.scss
+++ b/app/assets/stylesheets/_globals.scss
@@ -17,26 +17,10 @@
     outline: none;
 }
 
-input[type=email],
-input[type=text],
-input[type=number],
-textarea
-::-webkit-input-placeholder {
+::placeholder {
   color: transparentize($text, 0.5);
 }
 
-input[type=email],
-input[type=text],
-input[type=number],
-textarea
-::-moz-placeholder {
-  color: transparentize($text, 0.5);
-}
-
-input[type=email],
-input[type=text],
-input[type=number],
-textarea
 :-ms-input-placeholder {
   color: transparentize($text, 0.5) !important;
 }

--- a/app/assets/stylesheets/_globals.scss
+++ b/app/assets/stylesheets/_globals.scss
@@ -17,6 +17,30 @@
     outline: none;
 }
 
+input[type=email],
+input[type=text],
+input[type=number],
+textarea
+::-webkit-input-placeholder {
+  color: transparentize($text, 0.5);
+}
+
+input[type=email],
+input[type=text],
+input[type=number],
+textarea
+::-moz-placeholder {
+  color: transparentize($text, 0.5);
+}
+
+input[type=email],
+input[type=text],
+input[type=number],
+textarea
+:-ms-input-placeholder {
+  color: transparentize($text, 0.5) !important;
+}
+
 a{
     color: $blue;
     &:hover{
@@ -31,6 +55,10 @@ a{
 
 p{
     line-height: 1.5;
+}
+
+select::-ms-expand {
+  display: none;
 }
 
 .visually-hidden{

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -1,6 +1,5 @@
 @import "variables";
 
-
 .field-section{
     border: none;
     margin: 0;
@@ -61,9 +60,6 @@ textarea{
     &:focus{
         border-color: $yellow;
         background: transparentize($yellow, 0.9)
-    }
-    &::placeholder{
-        color: transparentize($text, 0.5)
     }
     &:invalid{
         outline: none;

--- a/app/assets/stylesheets/mini-search.scss
+++ b/app/assets/stylesheets/mini-search.scss
@@ -13,9 +13,6 @@
         border-bottom: 1px solid $text;
         width: 100%;
         padding-right: 50px;
-        &::placeholder{
-            color: transparentize($text, 0.5);
-        }
         &:focus{
             outline: none;
             border-color: $yellow;


### PR DESCRIPTION
Background:
https://trello.com/c/WVVMmJfY/308-ie-11-concerns

Solution:
- An extra arrow was appearing on IE 11 select boxes. Added the required pseudo-class to hide it.
- Added required vendor prefixes to style placeholders across different browsers