### PR TITLE
Hotfix: use simple_format in need name/description

### DIFF
--- a/app/views/needs/show.html.erb
+++ b/app/views/needs/show.html.erb
@@ -31,7 +31,7 @@
 
         <dl class="details-list">
           <dt class="details-list__caption">Description</dt>
-          <dd class="details-list__value"><%= @need.name %></dd>
+          <dd class="details-list__value"><%= simple_format @need.name %></dd>
 
           <% if @need.food_priority %>
             <dt class="details-list__caption">Food requirements priority</dt>


### PR DESCRIPTION
This allows for line breaks in need descriptions (the `name` field), which are now needed because the re-import has a ton of them. I've tested this in staging.