### PR TITLE
12. Quick capture referral Design 

### DIFF
--- a/app/assets/stylesheets/content-header.scss
+++ b/app/assets/stylesheets/content-header.scss
@@ -15,8 +15,8 @@
         justify-content: space-between;
         align-items: center;
     }
-    .content-header__current-user{
-        margin-right: 10px;
+    .content-header__add-enquiry {
+      margin-right: 10px;
     }
 
     .content-header__roles {

--- a/app/assets/stylesheets/nav.scss
+++ b/app/assets/stylesheets/nav.scss
@@ -25,6 +25,24 @@
         width: 100%;
         display: block;
     }
+
+    .nav-bottom {
+      position: fixed;
+      bottom: 10px;
+      display: flex;
+      flex-direction: column;
+      .current-user {
+        color: $pale;
+        margin-bottom: 10px;
+      }
+      .button.button--small {
+        color: $pale;
+        border-color: $pale;
+      }
+      .button.button--small:hover {
+        background-color: inherit;
+      }
+  }
     @media screen and (max-width: $breakpoint-l){
         width: 170px;
         min-width: 170px;

--- a/app/assets/stylesheets/need.scss
+++ b/app/assets/stylesheets/need.scss
@@ -46,3 +46,7 @@
         }
     }
 }
+
+.btn-triage {
+  margin-left: auto;
+}

--- a/app/assets/stylesheets/popup.scss
+++ b/app/assets/stylesheets/popup.scss
@@ -1,0 +1,42 @@
+@import "variables";
+
+.modal {
+  display: none;
+  position: fixed;
+  z-index: 1;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  background-color: rgb(0,0,0);
+  background-color: rgba(0,0,0,0.4);
+}
+
+.modal-header {
+  padding: 2px 16px;
+  text-align: center;
+  color: white;
+}
+
+.modal-content {
+  background-color: #fefefe;
+  margin: 15% auto;
+  padding: 20px;
+  border: 1px solid #888;
+  width: 60%;
+}
+
+.close {
+  color: #aaa;
+  float: right;
+  font-size: 28px;
+  font-weight: bold;
+}
+
+.close:hover,
+.close:focus {
+  color: black;
+  text-decoration: none;
+  cursor: pointer;
+}

--- a/app/javascript/packs/enquiry-common.js
+++ b/app/javascript/packs/enquiry-common.js
@@ -1,0 +1,36 @@
+let _this = {};
+function Popup() {
+    this.modalSelectorId = "mainModal";
+    this.headerSeletorClass = "modal-header";
+    this.contentAreaId = "modalContent";
+    this.closeIconClass = "close";
+
+    _this = this;
+
+    $(`.${this.closeIconClass}`).click(function() {
+        _this.close();
+    })
+}
+
+Popup.prototype.show = function(content, header = undefined) {
+    let modalWindow = $(`#${_this.modalSelectorId}`);
+    let contentArea = modalWindow.find(`#${_this.contentAreaId}`);
+    contentArea.html(content);
+    if (header) {
+        let headerArea = $(`.${_this.headerSeletorClass} h2`);
+        headerArea.text(header);
+    }
+    modalWindow.css("display", "block");
+};
+
+Popup.prototype.close = function() {
+    let modalWindow = $(`#${_this.modalSelectorId}`);
+    modalWindow.css("display", "none");
+};
+
+$(document).ready(() => {
+    $("#btnAddEnquiry").click(function() {
+        const popup = new Popup();
+        popup.show("<p>My content</p>", "This is my header");
+    })
+})

--- a/app/views/contacts/show.html.erb
+++ b/app/views/contacts/show.html.erb
@@ -1,11 +1,6 @@
-<% content_for :header do %>
-  <%= link_to "Triage", contact_triage_path(@contact), class: "button button--dark" %>
-<% end %>
-
 <%= render "shared/vulnerable-banner" %>
 
 <div class="with-left-sidebar">
-
   <aside class="with-left-sidebar__left">
     <header class="panel-header">
       <h2 class="panel-header__title">Profile</h2>
@@ -29,7 +24,8 @@
       <% if @open_needs.any? %>
         <span class="panel-header__badge"><%= @open_needs.count %></span>
       <% end %>
-      <%#= link_to "Add a need", new_contact_need_path(@contact), class: "panel-header__action" %>
+
+      <%= link_to "Triage", contact_triage_path(@contact), class: "btn-triage button button--dark" %>
     </header>
     <div class="panel panel--unpadded">  
       <%= render "needs-table" %>
@@ -39,7 +35,7 @@
       <header class="panel-header" id="completed-needs-panel">
         <h2 class="panel-header__title">Completed</h2>
       </header>
-      <div class="panel panel--unpadded">  
+      <div class="panel panel--unpadded">
         <table class="needs-table">
           <thead class="visually-hidden">
             <tr>

--- a/app/views/contacts/show.html.erb
+++ b/app/views/contacts/show.html.erb
@@ -12,6 +12,10 @@
 
   <aside class="with-left-sidebar__right">
 
+    <header class="panel-header" id="triage-panel">
+      <%= link_to "Triage", contact_triage_path(@contact), class: "btn-triage button button--dark" %>  
+    </header>
+
     <header class="panel-header" id="enquiry-details-panel">
       <h2 class="panel-header__title">Enquiry Details</h2>
     </header>
@@ -23,9 +27,7 @@
       <h2 class="panel-header__title">Needs</h2>
       <% if @open_needs.any? %>
         <span class="panel-header__badge"><%= @open_needs.count %></span>
-      <% end %>
-
-      <%= link_to "Triage", contact_triage_path(@contact), class: "btn-triage button button--dark" %>
+      <% end %>     
     </header>
     <div class="panel panel--unpadded">  
       <%= render "needs-table" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,7 +33,6 @@
     <%= render :partial =>  "shared/popup" %>
 
     <%= javascript_pack_tag 'role-switcher' %>
-    <%= javascript_pack_tag 'popup' %>
     <%= javascript_pack_tag 'enquiry-common' %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,22 +10,7 @@
       <header class="panel content-header">
         <%= yield :header %>
         <nav class="content-header__actions-right">
-
-          <div class="content-header__roles">
-            <% if current_user.roles.count > 1 %>
-              <%# Switch role section %>
-              <%= form_tag(set_role_path, :method => :post, :class => 'role-switcher') do %>
-                <%= label_tag :id, 'Role:' %>
-                <%= select_tag :id, options_from_collection_for_select(current_user.roles.order(:id), :id, :name, current_user.role_id) %>
-                <%= submit_tag 'Switch' %>
-              <% end %>
-            <% else %>
-              (<%= current_user.role.name %>)
-            <% end %>
-          </div>
-
-          <span class="content-header__current-user"><%= current_user.email %></span>
-          <%= link_to 'Log out', auth.sign_out_path, class: "button button--small" %>
+          <%= link_to "Add Enquiry", new_contact_path, {:remote => true, 'data-toggle' => "modal", 'data-target' => '#modal-window', id: "btnAddEnquiry", class: "button button--dark" } %>
         </nav>
       </header>
       
@@ -45,6 +30,10 @@
 
     </div>
 
-  <%= javascript_pack_tag 'role-switcher' %>
+    <%= render :partial =>  "shared/popup" %>
+
+    <%= javascript_pack_tag 'role-switcher' %>
+    <%= javascript_pack_tag 'popup' %>
+    <%= javascript_pack_tag 'enquiry-common' %>
   </body>
 </html>

--- a/app/views/needs/show.html.erb
+++ b/app/views/needs/show.html.erb
@@ -1,7 +1,3 @@
-<% content_for :header do %>
-  <%= link_to "Triage", contact_triage_path(@contact), class: "button button--dark" %>
-<% end %>
-
 <%= render "shared/vulnerable-banner" %>
 
 <div class="with-left-sidebar">
@@ -21,7 +17,8 @@
       <% if @contact.needs.any? %>
         <span class="panel-header__badge"><%= @contact.needs.count %></span>
       <% end %>
-      <%#= link_to "Add a need", new_contact_need_path(@contact), class: "panel-header__action" %>
+
+      <%= link_to "Triage", contact_triage_path(@contact), class: "btn-triage button button--dark" %>
     </header>
     <div class="panel panel--unpadded" style="border-left: 5px solid <%= get_need_border(@need.category) %>">
       <%= link_to @need.category.humanize, @contact, class: "panel__header" %>

--- a/app/views/shared/_popup.erb
+++ b/app/views/shared/_popup.erb
@@ -1,0 +1,10 @@
+<div id="mainModal" class="modal">
+  <div class="modal-content">
+    <div class="modal-header">
+      <span class="close">&times;</span>
+      <h2></h2>
+    </div>
+    <div id="modalContent" class="modal-body">
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_side-nav.html.erb
+++ b/app/views/shared/_side-nav.html.erb
@@ -51,6 +51,6 @@
 
     <div class="nav-bottom">
       <span class="current-user"><%= current_user.email %></span>
-      <%= link_to 'Sign out', auth.sign_out_path, class: "button button--small" %>
+      <%= link_to 'Sign out', auth.sign_out_path, class: "button button--small", id: "sign-out-link"%>
     </div>
 </nav>

--- a/app/views/shared/_side-nav.html.erb
+++ b/app/views/shared/_side-nav.html.erb
@@ -49,4 +49,8 @@
       <% end %>
     </ul>
 
+    <div class="nav-bottom">
+      <span class="current-user"><%= current_user.email %></span>
+      <%= link_to 'Sign out', auth.sign_out_path, class: "button button--small" %>
+    </div>
 </nav>

--- a/features/step_definitions/authentication_steps.rb
+++ b/features/step_definitions/authentication_steps.rb
@@ -1,20 +1,20 @@
 Given(/^I am logged into the system$/) do
   visit generate_magic_link
   expect(page.status_code).to eq(200) if Capybara.current_driver == :rack_test
-  expect(page).to have_selector(:link_or_button, 'Log out')
+  expect(page).to have_selector('#sign-out-link')
 end
 
 Given(/^I am logged into the system as an admin$/) do
   visit generate_magic_link(true)
   expect(page.status_code).to eq(200) if Capybara.current_driver == :rack_test
-  expect(page).to have_selector(:link_or_button, 'Log out')
+  expect(page).to have_selector('#sign-out-link')
 end
 
 Given(/^Someone else is logged into the system$/) do
   Capybara.using_session('Second_users_session') do
     visit generate_magic_link(false)
     expect(page.status_code).to eq(200) if Capybara.current_driver == :rack_test
-    expect(page).to have_selector(:link_or_button, 'Log out')
+    expect(page).to have_selector('#sign-out-link')
   end
 end
 


### PR DESCRIPTION

Background:
https://trello.com/c/TGmpxL1m/359-12-quick-capture-referral

Solution: 
- Moved name and sign out at the bottom left
![image](https://user-images.githubusercontent.com/63452375/80201569-02644f00-862d-11ea-82b0-e7473430b847.png)

- Moved Triage button above the needs table
![image](https://user-images.githubusercontent.com/63452375/80201631-190aa600-862d-11ea-887b-7a23fba81af0.png)

- Moved the Add Enquiry button at the top right corner
![image](https://user-images.githubusercontent.com/63452375/80201701-2e7fd000-862d-11ea-8605-49f2c700a013.png)
