### PR TITLE
Refactor: Use enum for need category

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,4 @@ Coming soon...
 | NOTIFY_API_KEY   | Gov.uk Notify API key (production only)   |
 | HOSTNAME         | Hostname used in outbound emails (e.g. `x.beacon.com`). Defaults to heroku app name |
 | SEED_USER_EMAILS | Optional comma-separated list of emails to seed users table with |
+

--- a/app/assets/stylesheets/_layout.scss
+++ b/app/assets/stylesheets/_layout.scss
@@ -27,6 +27,10 @@ body{
     &.panel--unpadded{
         padding: 0px;
     }
+    &.panel--stroked {
+        border-left-width: 5px;
+        border-left-style: solid;
+    }
     .panel__header{
         border: none;
         padding: 25px 35px;

--- a/app/assets/stylesheets/need-accents.scss
+++ b/app/assets/stylesheets/need-accents.scss
@@ -1,0 +1,29 @@
+@import "variables";
+
+.need--phone-triage {
+  border-left-color: $text;
+}
+.need--groceries-and-cooked-meals {
+  border-left-color: #EAD95B;
+}
+.need--physical-and-mental-wellbeing {
+  border-left-color: #F18F01;
+}
+.need--financial-support {
+  border-left-color: #42807B;
+}
+.need--staying-social {
+  border-left-color: #A0CAC9;
+}
+.need--prescription-pickups {
+  border-left-color: #971964;
+}
+.need--book-drops-and-entertainment {
+  border-left-color: #43387B;
+}
+.need--dog-walking {
+  border-left-color: #1C52A3;
+}
+.need--initial-review {
+  border-left-color: $text;
+}

--- a/app/assets/stylesheets/table.scss
+++ b/app/assets/stylesheets/table.scss
@@ -107,6 +107,8 @@
     tbody{
         tr{
             border-top: 1px solid transparentize($text, 0.8);
+            border-left-width: 10px;
+            border-left-style: solid;
             cursor: pointer;
             &:hover{
                 background: transparentize($blue, 0.9);

--- a/app/assets/stylesheets/triage.scss
+++ b/app/assets/stylesheets/triage.scss
@@ -9,10 +9,11 @@
     }
     .triage-grid__need{
         margin: none;
-        border: none;
         background: $white;
         box-shadow: 2px 0px 10px transparentize($text, 0.95);
         margin-bottom: 30px;
+        border-left-width: 5px;
+        border-left-style: solid;
     }
     .triage-grid__inner{
         padding: 35px;

--- a/app/controllers/triage_controller.rb
+++ b/app/controllers/triage_controller.rb
@@ -61,8 +61,8 @@ class TriageController < ApplicationController
 
   # repopulate the label/colour data
   def merge_contact_needs
-    @contact_needs.needs_list.each_with_index do |need, index|
-      need[1].merge!(view_context.needs[index])
+    @contact_needs.needs_list.each_with_index do |need, _index|
+      need[1]
     end
   end
 
@@ -85,9 +85,12 @@ class TriageController < ApplicationController
 
   def create_contact_needs
     contact_model = ContactNeeds.new
-    contact_model.needs_list = view_context.needs.each_with_index.map do |need, index|
-      need[:active] = 'false'
-      need[:start_on] = (Date.today + 6.days).strftime('%d/%m/%Y') if need[:label] == 'Phone triage'
+    contact_model.needs_list = Need.categories_for_triage.each_with_index.map do |(label, _slug), index|
+      need = {
+        label: label,
+        active: false
+      }
+      need[:start_on] = (Date.today + 6.days).strftime('%d/%m/%y') if label == 'Phone triage'
       [index.to_s, need]
     end.to_h
     contact_model

--- a/app/controllers/triage_controller.rb
+++ b/app/controllers/triage_controller.rb
@@ -10,7 +10,6 @@ class TriageController < ApplicationController
     if session[:triage] && session[:triage][:contact_id] == @contact.id
       @contact.assign_attributes(session[:triage][:contact_params])
       @contact_needs = ContactNeeds.new(session[:triage][:contact_needs_params])
-      merge_contact_needs
     else
       @contact_needs = create_contact_needs
     end
@@ -28,7 +27,6 @@ class TriageController < ApplicationController
     end
   rescue ActiveRecord::StaleObjectError
     flash[:alert] = STALE_ERROR_MESSAGE
-    merge_contact_needs
     render :edit
   end
 
@@ -40,10 +38,7 @@ class TriageController < ApplicationController
     @contact_needs.valid?
     @contact.valid?
 
-    if @contact.errors.any? || @contact_needs.errors.any? || !@contact.save
-      merge_contact_needs
-      render(:edit) && return
-    end
+    render(:edit) && return if @contact.errors.any? || @contact_needs.errors.any? || !@contact.save
 
     ContactChannel.broadcast_to(@contact, { userEmail: current_user.email, type: 'CHANGED' })
     NeedsCreator.create_needs(@contact, contact_needs_params['needs_list'], contact_needs_params['other_need'])
@@ -57,13 +52,6 @@ class TriageController < ApplicationController
       contact_params: contact_params,
       contact_needs_params: contact_needs_params
     }
-  end
-
-  # repopulate the label/colour data
-  def merge_contact_needs
-    @contact_needs.needs_list.each_with_index do |need, _index|
-      need[1]
-    end
   end
 
   def set_contact
@@ -87,12 +75,19 @@ class TriageController < ApplicationController
     contact_model = ContactNeeds.new
     contact_model.needs_list = Need.categories_for_triage.each_with_index.map do |(label, _slug), index|
       need = {
-        label: label,
+        name: label,
         active: false
       }
-      need[:start_on] = (Date.today + 6.days).strftime('%d/%m/%y') if label == 'Phone triage'
+      if label == 'Phone triage'
+        need[:active] =
+          need[:start_on] = (Date.today + 6.days).strftime('%d/%m/%y')
+      end
       [index.to_s, need]
     end.to_h
     contact_model
+  end
+
+  def submitted_value(need_type)
+    contact_needs_params[:needs_list].values.find { |k| k[:name] == need_type }
   end
 end

--- a/app/helpers/needs_helper.rb
+++ b/app/helpers/needs_helper.rb
@@ -9,32 +9,6 @@ module NeedsHelper
     ['Vulnerable']
   end
 
-  def need_categories
-    %w[Food Medicine Other]
-  end
-
-  def needs
-    [
-      { label: 'Phone triage', border: '#2A2828' },
-      { label: 'Groceries and cooked meals', border: '#EAD95B' },
-      { label: 'Physical and mental wellbeing', border: '#F18F01' },
-      { label: 'Financial support', border: '#42807B' },
-      { label: 'Staying social', border: '#A0CAC9' },
-      { label: 'Prescription pickups', border: '#971964' },
-      { label: 'Book drops and entertainment', border: '#43387B' },
-      { label: 'Dog walking', border: '#1C52A3' },
-      { label: 'Initial review', border: '#1C52A3' }
-    ]
-  end
-
-  def get_need_border(category)
-    (needs.find { |need| need[:label].parameterize.underscore.humanize.downcase == category })&.[](:border) || ''
-  end
-
-  def needs_labels_list
-    needs.map { |need| need[:label] }
-  end
-
   def note_category_form_display(note_category)
     note_category[0].to_s if note_category.present?
   end

--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -18,6 +18,17 @@ class Need < ApplicationRecord
                  food_priority: :string,
                  food_service_type: :string
 
+  enum category: { 'Phone triage': 'phone triage',
+                   'Groceries and cooked meals': 'groceries and cooked meals',
+                   'Physical and mental wellbeing': 'physical and mental wellbeing',
+                   'Financial support': 'financial support',
+                   'Staying social': 'staying social',
+                   'Prescription pickups': 'prescription pickups',
+                   'Book drops and entertainment': 'book drops and entertainment',
+                   'Dog walking': 'dog walking',
+                   'Initial review': 'initial review',
+                   'Other': 'other' }
+
   # validates :food_priority, inclusion: { in: %w[1 2 3] }, allow_blank: true
   # validates :food_service_type, inclusion: { in: ['Hot meal', 'Heat up', 'Grocery delivery'] }, allow_blank: true
 
@@ -135,6 +146,10 @@ class Need < ApplicationRecord
 
   def self.dynamic_fields
     %w[last_phoned_date]
+  end
+
+  def self.categories_for_triage
+    categories.except('Other')
   end
 
   def assigned

--- a/app/validators/contact_needs_validator.rb
+++ b/app/validators/contact_needs_validator.rb
@@ -3,7 +3,7 @@ class ContactNeedsValidator < ActiveModel::Validator
     form.needs_list.values.each_with_index do |need, _index|
       next unless need[:active] == 'true'
 
-      if need[:name] == 'phone_triage'
+      if need[:name] == 'Phone triage'
         form.errors.add('Phone triage call date', 'is not a valid date') unless valid_date? need[:start_on]
       end
     end

--- a/app/views/contacts/_needs-table.html.erb
+++ b/app/views/contacts/_needs-table.html.erb
@@ -11,9 +11,9 @@
           </thead>
           <tbody>
             <% @open_needs.each do |n| %>
-              <tr onclick="window.location='<%= need_path(n) %>'">
-                <td style="border-left: 10px solid <%= get_need_border(n.category) %>">
-                  <%= link_to n.category.humanize, n %>
+              <tr onclick="window.location='<%= need_path(n) %>'" class="need--<%= n.category.parameterize %>">
+                <td>
+                  <%= link_to n.category, n %>
                 </td>
                 <td>
                   <% if n.is_urgent %>

--- a/app/views/contacts/show.html.erb
+++ b/app/views/contacts/show.html.erb
@@ -51,9 +51,9 @@
           </thead>
           <tbody>
             <% @completed_needs.each do |n| %>
-                <tr onclick="window.location='<%= need_path(n) %>'">
-                <td style="border-left: 10px solid <%= get_need_border(n.category) %>">
-                  <%= link_to n.category.humanize, n %>
+                <tr onclick="window.location='<%= need_path(n) %>'" class="need--<%= n.category.parameterize %>">
+                <td>
+                  <%= link_to n.category, n %>
                 </td>
                 <td>
                   <% if n.is_urgent %>

--- a/app/views/needs/_filters.html.erb
+++ b/app/views/needs/_filters.html.erb
@@ -12,7 +12,7 @@
           <%= select_tag("user_id", content_tag(:option,'Unassigned',:value => "Unassigned", :selected => params["user_id"] == "Unassigned") + options_from_collection_for_select(@users, :id, :name_or_email, :selected => params['user_id']), prompt: 'All users', class: "filters__select") %>
 
           <label for="category" class="visually-hidden">By category</label>
-          <%= select_tag("category", content_tag(:option,'Other',:value => "Other", :selected => params["category"] == "Other") + options_for_select(needs_labels_list, :selected => get_param_capitalized('category')), prompt: 'All categories', class: "filters__select") %>
+          <%= select_tag("category", options_for_select(Need.categories, :selected => params["category"]), prompt: 'All categories', class: "filters__select") %>
         
           <label for="status" class="visually-hidden">By status</label>
           <%= select_tag("status", options_for_select(need_statuses, :selected => params["status"]), prompt: 'All statuses', class: "filters__select") %>

--- a/app/views/needs/index.html.erb
+++ b/app/views/needs/index.html.erb
@@ -72,7 +72,7 @@
             <%= check_box_tag("need[#{n.id}]", n.id, false, { class: "select-needs bulk-action-checkbox" }) %>
           </td>
           <td>
-            <%= link_to humanize_text(n.category), n, class: "primary-link" %>
+            <%= link_to n.category, n, class: "primary-link" %>
           </td>
           <td><%= n.contact_name %></td>
           <td>

--- a/app/views/needs/show.html.erb
+++ b/app/views/needs/show.html.erb
@@ -21,8 +21,8 @@
         <%= link_to "Triage", contact_triage_path(@contact), class: "btn-triage button button--dark" %>
       <% end %>
     </header>
-    <div class="panel panel--unpadded" style="border-left: 5px solid <%= get_need_border(@need.category) %>">
-      <%= link_to @need.category.humanize, @contact, class: "panel__header" %>
+    <div class="panel panel--unpadded panel--stroked need--<%= @need.category.parameterize %>">
+      <%= link_to @need.category, @contact, class: "panel__header" %>
       <div class="panel__body">
 
         <%= render "need-actions" %>

--- a/app/views/triage/edit.html.erb
+++ b/app/views/triage/edit.html.erb
@@ -38,7 +38,7 @@
     <% @contact_needs.needs_list.each do |need_entry| %>
       <% need = need_entry[1] %>
       <%= form.fields_for 'needs_list', :index => need_entry[0] do |need_form| %>       
-        <div class="triage-grid__need" style="border-left: 5px solid <%= need[:border] %>">
+        <div class="triage-grid__need need--<%= need[:label].parameterize %>">
           <div class="triage-grid__inner">
             <h3 class="triage-grid__title"><%= need[:label] %></h3>
 

--- a/app/views/triage/edit.html.erb
+++ b/app/views/triage/edit.html.erb
@@ -38,11 +38,11 @@
     <% @contact_needs.needs_list.each do |need_entry| %>
       <% need = need_entry[1] %>
       <%= form.fields_for 'needs_list', :index => need_entry[0] do |need_form| %>       
-        <div class="triage-grid__need need--<%= need[:label].parameterize %>">
+        <div class="triage-grid__need need--<%= need[:name] %>">
           <div class="triage-grid__inner">
-            <h3 class="triage-grid__title"><%= need[:label] %></h3>
+            <h3 class="triage-grid__title"><%= need[:name].humanize %></h3>
 
-            <%= need_form.hidden_field :name, :value => need[:label].parameterize.underscore %>
+            <%= need_form.hidden_field :name, :value => need[:name] %>
 
             <fieldset class="field-section field-section--two-cols">
               <legend class="field-section__title">Is this needed?</legend>
@@ -68,10 +68,10 @@
           </div>
 
           <%= fields_for :contact, @contact do |contact_form| %>
-            <% if File.exists?(Rails.root.join("app", "views", params[:controller], "_#{need[:label].parameterize.underscore}.html.erb")) %>
+            <% if File.exists?(Rails.root.join("app", "views", params[:controller], "_#{need[:name].parameterize.underscore}.html.erb")) %>
               <%# form will save to the need, contact_form will save to the contact %>
               <div class="triage-grid__inner triage-grid__inner--grey">
-                <%= render :partial => "#{need[:label].parameterize.underscore}", locals: {form: contact_form, need_form: need_form, need: need } %>
+                <%= render :partial => "#{need[:name].parameterize.underscore}", locals: {form: contact_form, need_form: need_form, need: need } %>
               </div>
             <% end %>
           <% end %>

--- a/features/list_needs.feature
+++ b/features/list_needs.feature
@@ -46,4 +46,4 @@ Feature: List needs
   Scenario: Sort needs by category descending
     Given a resident with "Book drops and entertainment, Dog walking, Groceries and cooked meals" needs
     When I sort needs by category in "DESC" order
-    Then I see the need for category "Groceries and cooked meals" first in the results
+    Then I see the need for category "Groceries and cooked meals" first in the results

--- a/features/step_definitions/edit_need_steps.rb
+++ b/features/step_definitions/edit_need_steps.rb
@@ -1,6 +1,6 @@
 Given('a resident with a need exists') do
   @contact = Contact.create!(first_name: 'Test')
-  @need = Need.create!(contact_id: @contact.id, name: 'Phone Triage', category: 'Phone Triage')
+  @need = Need.create!(contact_id: @contact.id, name: 'Phone Triage', category: 'Phone triage')
 end
 
 When('I (assign)/(have assigned) the need to me') do

--- a/features/step_definitions/needs_list_steps.rb
+++ b/features/step_definitions/needs_list_steps.rb
@@ -12,7 +12,7 @@ end
 
 When('I filter needs by category {string}') do |category|
   page.find('#needs-filters').click
-  find('#category').find("option[value='#{category}']").select_option
+  find('#category').select(category)
 end
 
 Then('I see the need for category {string} in the results') do |category|

--- a/features/step_definitions/permissions/permissions_search_steps.rb
+++ b/features/step_definitions/permissions/permissions_search_steps.rb
@@ -1,6 +1,6 @@
 And('another contact {string} is not visible to me') do |name|
   @another_contact = Contact.create!(first_name: name + rand(10**10).to_s(36))
-  @another_need = Need.create!(contact: @another_contact, name: 'Phone Triage', category: 'Phone Triage')
+  @another_need = Need.create!(contact: @another_contact, name: 'Phone Triage', category: 'Phone triage')
 end
 
 Then('I can see the permitted contact in the list') do

--- a/features/step_definitions/permissions/permissions_steps.rb
+++ b/features/step_definitions/permissions/permissions_steps.rb
@@ -13,17 +13,17 @@ end
 
 And('a need for contact {string} is assigned to me') do |name|
   @contact = Contact.create!(first_name: name + rand(10**10).to_s(36))
-  @need = Need.create!(contact: @contact, name: 'Phone Triage', category: 'Phone Triage', user: @user)
+  @need = Need.create!(contact: @contact, name: 'Phone Triage', category: 'Phone triage', user: @user)
 end
 
 And('a need for contact {string} is assigned to that role') do |name|
   @contact = Contact.create!(first_name: name + rand(10**10).to_s(36))
-  @need = Need.create!(contact: @contact, name: 'Phone Triage', category: 'Phone Triage', role: @role)
+  @need = Need.create!(contact: @contact, name: 'Phone Triage', category: 'Phone triage', role: @role)
 end
 
 And('a need for contact {string} is assigned to the other user') do |name|
   @contact = Contact.create!(first_name: name + rand(10**10).to_s(36))
-  @need = Need.create!(contact: @contact, name: 'Phone Triage', category: 'Phone Triage', user: @other_user)
+  @need = Need.create!(contact: @contact, name: 'Phone Triage', category: 'Phone triage', user: @other_user)
 end
 
 When('I go to the contact page for that need/contact') do

--- a/spec/factories/needs.rb
+++ b/spec/factories/needs.rb
@@ -1,23 +1,11 @@
 # frozen_string_literal: true
 
 FOOD_CATEGORY = 'groceries and cooked meals'
-need_categories = [
-  'phone triage',
-  'groceries and cooked meals',
-  'physical and mental wellbeing',
-  'financial support',
-  'staying social',
-  'prescription pickups',
-  'book drops and entertainment',
-  'dog walking',
-  'other',
-  'initial review'
-]
 
 FactoryBot.define do
   factory :need do
     contact
-    category { need_categories.sample }
+    category { Need.categories.values.sample }
     name { Faker::Lorem.sentence }
     start_on { [nil, Faker::Date.between(from: 2.days.ago, to: 6.days.from_now)].sample }
 

--- a/spec/helpers/needs_helper_spec.rb
+++ b/spec/helpers/needs_helper_spec.rb
@@ -3,12 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe NeedsHelper do
-  describe '#needs' do
-    it 'returns a list of needs' do
-      expect(helper.needs.count).to be > 0
-    end
-  end
-
   describe '#note_category_display' do
     it 'returns appropriate display values when given a note category' do
       display_texts = ['Note', 'Successful Call', 'Left Message', 'Failed Call', 'Imported Call Log']


### PR DESCRIPTION
This refactor uses an enum for `category` in the need model, which simplifies working with the list of categories a bit.

Significantly, it moves the border/stroke colours to CSS. This involves hard-coding categories in CSS classes. I considered simply having a CSS variable that was a list of colours, and the stroke colour would be based on the index in the enum. That would probably be better but might be a bit less obvious what's going on, so this seemed fine. I could go either way though.

I've got some failing cucumber tests, and I _think_ it may be because of some of my refactoring in the triage controller. In particular, I'm not sure what `merge_contact_needs` was meant to do or if we still need it now that colours aren't involved in the list. @jamiebuckley can you take a peek when you have a free minute?

This is not an urgent feature — and I'm fine with discarding it — but my hope is it may make it slightly easier to implement some of the other features we need to do, and also demonstrates how to fix the filtering bug on the status column (cc @go8soft).