### PR TITLE
User name overflowing navigation menu

### DIFF
--- a/app/assets/stylesheets/nav.scss
+++ b/app/assets/stylesheets/nav.scss
@@ -34,6 +34,8 @@
       .current-user {
         color: $pale;
         margin-bottom: 10px;
+        text-align: center;
+        word-wrap: break-word;
       }
       .button.button--small {
         color: $pale;
@@ -41,6 +43,14 @@
       }
       .button.button--small:hover {
         background-color: inherit;
+      }
+
+      @media only screen and (max-width: 1100px) {
+        max-width: 130px;
+      }
+
+      @media only screen and (min-width: 1101px) {
+        max-width: 190px;
       }
   }
     @media screen and (max-width: $breakpoint-l){


### PR DESCRIPTION
Background:
https://trello.com/c/efvDD3b4/408-user-name-overflowing-navigation-menu

Solution:
The bottom section is now responsible, so it can accommodate for different screen sizes. Also, the user name spans over multiple lines, if needed.

![image](https://user-images.githubusercontent.com/63452375/80354755-d55baa80-887f-11ea-8f31-5e02119b2fe8.png)

![image](https://user-images.githubusercontent.com/63452375/80354830-eefcf200-887f-11ea-9c23-899a5c9d0eb3.png)

![image](https://user-images.githubusercontent.com/63452375/80354886-02a85880-8880-11ea-9cd1-d9da01151647.png)

![image](https://user-images.githubusercontent.com/63452375/80354926-105dde00-8880-11ea-880b-ded1fec0c11c.png)
