### PR TITLE
When a need is assigned to a user, remove the team assignment, and vi…

### DIFF
--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -5,6 +5,7 @@ require 'csv'
 class Need < ApplicationRecord
   include Filterable
   self.ignored_columns = %w[due_by]
+  before_update :assign_to
 
   enum status: { to_do: 'to_do', in_progress: 'in_progress', blocked: 'blocked', complete: 'complete', cancelled: 'cancelled' }
   belongs_to :contact, counter_cache: true
@@ -136,6 +137,11 @@ class Need < ApplicationRecord
                           ''
                         end
     self[:status] = state
+  end
+
+  def assign_to
+    self.role_id = nil if !user.nil? && user_id_changed?
+    self.user_id = nil if !role_id.nil? && role_id_changed?
   end
 
   def self.base_query

--- a/spec/factories/roles.rb
+++ b/spec/factories/roles.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :role do
+    name { 'Food Hub' }
+    role { 'food_delivery_manager' }
+  end
+end

--- a/spec/models/need_spec.rb
+++ b/spec/models/need_spec.rb
@@ -80,4 +80,33 @@ RSpec.describe Need, type: :model do
       expect(needs[1].name).to eq 'created tomorrow, no start date'
     end
   end
+
+  describe 'assing user or team at the same moment' do
+    let(:user) { create :user }
+    let(:role) { create :role }
+
+    it 'update need with user and role at the same time' do
+      need = create :need, name: 'medicines'
+      need.update user: user, role: role
+
+      expect(need.user).to be user
+      expect(need.role).to be_nil
+    end
+
+    it 'update need with role to have user' do
+      need = create :need, name: 'medicines', role: role
+      need.update user: user
+
+      expect(need.user).to be user
+      expect(need.role).to be_nil
+    end
+
+    it 'update need with user to have role' do
+      need = create :need, name: 'medicines', user: user
+      need.update role: role
+
+      expect(need.user).to be_nil
+      expect(need.role).to be_role
+    end
+  end
 end


### PR DESCRIPTION
When a need is assigned to a user, remove the team assignment, and vice-versa

Task: https://trello.com/c/7ifDPBRM/433-when-a-need-is-assigned-to-a-user-remove-the-team-assignment-and-vice-versa