### PR TITLE
Warn users if they’re leaving the create/edit contact page with unsaved changes

### DIFF
--- a/app/javascript/packs/contact-form-navigation-alert.js
+++ b/app/javascript/packs/contact-form-navigation-alert.js
@@ -1,0 +1,23 @@
+$(() => {
+   $("body").attr("data-turbolinks", false);
+
+   const formElement = $("form");
+   const originalState = formElement.serialize();
+   formElement.on("submit", onSubmit)
+
+   function shouldNavigateDirectly() {
+      const currentState = $("form").serialize();
+
+      $("*").blur();
+      return currentState === originalState ? undefined : false;
+   };
+
+   function onSubmit() {
+      $(window).off("beforeunload", shouldNavigateDirectly);
+   }
+
+   $(window).on("beforeunload", shouldNavigateDirectly);
+})
+
+
+

--- a/app/javascript/packs/contact-form-navigation-alert.js
+++ b/app/javascript/packs/contact-form-navigation-alert.js
@@ -1,7 +1,7 @@
 $(() => {
    $("body").attr("data-turbolinks", false);
 
-   const formElement = $("form");
+   const formElement = $("form.contact-form");
    const originalState = formElement.serialize();
    formElement.on("submit", onSubmit)
 

--- a/app/views/contacts/_form.html.erb
+++ b/app/views/contacts/_form.html.erb
@@ -1,5 +1,5 @@
 <div class="two-thirds">
-  <%= form_with(model: contact, local: true) do |form| %>
+  <%= form_with(model: contact, local: true, html: { class: "contact-form" }) do |form| %>
     <%= render partial: 'form_fields', locals: { contact: @contact, form: form } %>
     <div class="actions">
       <%= form.button "Save changes", class: "button button--primary" %>

--- a/app/views/contacts/edit.html.erb
+++ b/app/views/contacts/edit.html.erb
@@ -9,3 +9,4 @@
 
 
 <%= javascript_pack_tag 'users_viewing_page.js' %>
+<%= javascript_pack_tag 'contact-form-navigation-alert.js' %>

--- a/app/views/contacts/new.html.erb
+++ b/app/views/contacts/new.html.erb
@@ -5,7 +5,7 @@
 
 <!-- New contact form -->
 <div class="panel">
-  <%= form_with(model: @contact, local: true, class: "margin-bottom-70 two-thirds") do |f| %>   
+  <%= form_with(model: @contact, local: true, class: "margin-bottom-70 two-thirds contact-form") do |f| %>
     
     <section class="field-section field-section--two-cols">
     

--- a/app/views/contacts/new.html.erb
+++ b/app/views/contacts/new.html.erb
@@ -65,3 +65,6 @@
     </section>
   <% end %>
 </div>
+
+
+<%= javascript_pack_tag 'contact-form-navigation-alert.js' %>


### PR DESCRIPTION
Background:
https://trello.com/c/3BZgNJez/428-warn-users-if-theyre-leaving-the-create-edit-contact-page-with-unsaved-changes

Solution: 
- I use the "onbeforeunload" event. Since rails turbo links prevent full page reload, I disable them only on the page where the warning is needed. After we leave the page, they are restored. 