### PR TITLE
Move export and filter buttons to the right, above the table

### DIFF
--- a/app/assets/stylesheets/_globals.scss
+++ b/app/assets/stylesheets/_globals.scss
@@ -45,6 +45,29 @@ select::-ms-expand {
   display: none;
 }
 
+.dropdown {
+  margin-left: 5px;
+  width: 135px;
+  appearence: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  border-radius: 0px;
+  padding: 5px;
+  border: none;
+  font-size: 0.9rem;
+  background: $pale;
+  cursor: pointer;
+  background-position: 90% center;
+  background-repeat: no-repeat;
+  background-size: 13px;
+  background-image: url(asset_path('select-dark.svg'));
+  text-overflow: ellipsis;
+  padding-right: 35px;
+  &:focus{
+    outline: 2px solid $yellow;
+  }
+}
+
 .visually-hidden{
     position: absolute !important;
     height: 1px; 

--- a/app/assets/stylesheets/bulk-actions.scss
+++ b/app/assets/stylesheets/bulk-actions.scss
@@ -1,34 +1,29 @@
 @import "variables";
 
 .bulk-actions{
+    display: flex;
     flex-direction: row;
     flex: 1 0 auto;
-    .assign__needs{
-        margin-left: 5px;
-        width: auto;
-        border-radius: 0px;
-        padding: 5px;
-        border: none;
-        font-size: 0.9rem;
-        background: $pale;
-        cursor: pointer;
-        background-position: 90% center;
-        background-repeat: no-repeat;
-        background-size: 13px;
-        background-image: url(asset_path('select-dark.svg'));
-        padding-right: 35px;
-        &:focus{
-            outline: 2px solid $yellow;
-        }
+    align-items: center;
+    .last-element {
+      margin-left: auto;
+      display: flex;
+      flex-direction: row-reverse;
+    }
+    #btnExport {
+      margin-left: 10px;
+    }
+    #assign-selected-needs-users, #assign-selected-needs-team {
+      width: 160px;
     }
 }
 
 .bulk-action-checkbox{
-  /* Double-sized Checkboxes */
-  -ms-transform: scale(2); /* IE */
-  -moz-transform: scale(2); /* FF */
-  -webkit-transform: scale(2); /* Safari and Chrome */
-  -o-transform: scale(2); /* Opera */
-  transform: scale(2);
+
+  -ms-transform: scale(1.5); /* IE */
+  -moz-transform: scale(1.5); /* FF */
+  -webkit-transform: scale(1.5); /* Safari and Chrome */
+  -o-transform: scale(1.5); /* Opera */
+  transform: scale(1.5);
   padding: 10px;
 }

--- a/app/views/needs/_bulk-actions.erb
+++ b/app/views/needs/_bulk-actions.erb
@@ -1,11 +1,18 @@
 <div id="assign-needs-to-users">
-  <div class="panel bulk-actions" style="display: default">
+  <div class="panel bulk-actions">
     <%= check_box_tag("select-all-needs", nil, false, { class: "select-all-needs bulk-action-checkbox" }) %>
-    
-    <%= select_tag("user_id", content_tag(:option,'Unassigned',:value => "Unassigned") + options_from_collection_for_select(@users, :id, :name_or_email), 
-        prompt: 'Assign to person', class: "assign__needs",  id: "assign-selected-needs-users") %>
 
-    <%= select_tag("role_id", content_tag(:option,'Unassigned',:value => "Unassigned") + options_from_collection_for_select(@roles, :id, :name), 
-        prompt: 'Assign to team', class: "assign__needs",  id: "assign-selected-needs-team") %>
+    <%= select_tag("user_id", content_tag(:option,'Unassigned',:value => "Unassigned") + options_from_collection_for_select(@users, :id, :name_or_email),
+                   prompt: 'Assign to person', class: "assign__needs",  id: "assign-selected-needs-users", class: "dropdown") %>
+
+    <%= select_tag("role_id", content_tag(:option,'Unassigned',:value => "Unassigned") + options_from_collection_for_select(@roles, :id, :name),
+                   prompt: 'Assign to team', class: "assign__needs",  id: "assign-selected-needs-team", class: "dropdown")  %>
+
+    <div class="last-element">
+      <%= link_to "Export", url_for(params: request.query_parameters, :format => 'csv'), id: "btnExport", class: "button button--dark" %>
+      <%= render "filters" %>
+    </div>
   </div>
 </div>
+
+<%= javascript_pack_tag 'filters' %>

--- a/app/views/needs/index.html.erb
+++ b/app/views/needs/index.html.erb
@@ -1,14 +1,3 @@
-<% content_for :header do %>
-  <%= link_to "Export", url_for(params: request.query_parameters, :format => 'csv'), class: "button button--dark" %>
-
-
-  <%= render "filters" %>
-
-
-<%= javascript_pack_tag 'filters', 'data-turbolinks-track': 'reload' %>
-
-<% end %>
-
 <header class="panel-header">
   <h1 class="panel-header__title">All support actions</h1>
 </header>


### PR DESCRIPTION
Background:
https://trello.com/c/jUyj4aiB/436-move-export-and-filter-buttons-to-the-right-above-the-table

Solution:
- Moved export and filter buttons to  the right, above the temple.
- Since text-overflow doesn't seem to work correctly on select element, except for Firefox, I made the roles assignment boxes wider, so not to clip the displayed text.

![image](https://user-images.githubusercontent.com/63452375/80594388-90747700-8a2b-11ea-84e9-be4608d450c0.png)
