### PR TITLE
Replace Google Tag Manager with Google Analytics and make it optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,4 +82,4 @@ Coming soon...
 | NOTIFY_API_KEY   | Gov.uk Notify API key (production only)   |
 | HOSTNAME         | Hostname used in outbound emails (e.g. `x.beacon.com`). Defaults to heroku app name |
 | SEED_USER_EMAILS | Optional comma-separated list of emails to seed users table with |
-
+| GA_PROPERTY_ID   | Optional Google Analytics property ID |

--- a/app/views/shared/_head.html.erb
+++ b/app/views/shared/_head.html.erb
@@ -6,12 +6,13 @@
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
 
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-162367132-2"></script>
-    <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-        gtag('config', '<%= ENV["GA_PROPERTY_ID"] %>');
-    </script>
+    <% if ENV['GA_PROPERTY_ID'] %>
+        <script>
+            window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+            ga('create', '<%= ENV['GA_PROPERTY_ID'] %>', 'auto');
+            ga('send', 'pageview');
+        </script>
+        <script async src='https://www.google-analytics.com/analytics.js'></script>
+    <% end %>
 
 </head>


### PR DESCRIPTION
This PR removes Google Tag Manager since we don't expect this to be managed and it's otherwise a big vector. In its place, it leaves the [google analytics snippet](https://developers.google.com/analytics/devguides/collection/analyticsjs/) and makes the whole thing optional.