### PR TITLE
Make the 'add assessment' button a dropdown like the designs

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -7,6 +7,7 @@ $pale: #EFEFEF;
 $white: #ffffff;
 
 $blue: #3A6CB5;
+$blue-hover: #e8f1fe;
 // $blue: #156BEC;
 
 $green: #22C99B;

--- a/app/assets/stylesheets/assessment.scss
+++ b/app/assets/stylesheets/assessment.scss
@@ -1,0 +1,43 @@
+@import "variables";
+
+.assessment-dropdown {
+  position: relative;
+  display: inline-block;
+  margin-right: 10px;
+  #btnAssessmentDropdown,
+  #btnAssessmentDropdown:focus,
+  #btnAssessmentDropdown:active {
+    color: $blue;
+    font-size: 1.2rem;
+    border: none;
+    cursor: pointer;
+    outline: none;
+    padding: 0;
+  }
+}
+
+.assessment-dropdown-content {
+  display: none;
+  position: absolute;
+  right: 5%;
+  background-color: $white;
+  min-width: 300px;
+  overflow: auto;
+  box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+  z-index: 1;
+
+  a {
+    color: black;
+    padding: 12px 16px;
+    text-decoration: none;
+    display: block;
+    text-align: left;
+    &:hover {
+      background-color: $blue-hover;
+    }
+  }
+}
+
+.assessment-dropdown-show {
+  display: block;
+}

--- a/app/javascript/packs/assessments.js
+++ b/app/javascript/packs/assessments.js
@@ -1,4 +1,4 @@
-document.querySelectorAll('.need--status_complete').forEach(e => e.style.display = 'none');
+Array.prototype.slice.call(document.querySelectorAll('.need--status_complete')).forEach((e, i) => e => e.style.display = 'none');
 
 let showCompletedNeeds = false;
 const toggleDisplay = (show) => show ? 'table-row' : 'none';
@@ -8,3 +8,20 @@ document.getElementById('toggle-visibility-completed-assessments').addEventListe
     document.querySelectorAll('.need--status_complete').forEach(e => e.style.display = toggleDisplay(showCompletedNeeds));
     e.preventDefault()
 });
+
+document.getElementById('btnAssessmentDropdown').addEventListener('click', (e) => {
+    document.getElementById('assessmentDropdownElements').classList.toggle('assessment-dropdown-show');
+    window.addEventListener('click', onWindowClick);
+
+    function onWindowClick(e) {
+        if (e.target.id.toString() !== 'btnAssessmentDropdown') {
+            const dropdown = document.getElementById('assessmentDropdownElements');
+            if (dropdown && dropdown.classList.contains('assessment-dropdown-show')) {
+                dropdown.classList.remove('assessment-dropdown-show');
+            }
+        }
+    }
+});
+
+
+

--- a/app/views/contacts/show.html.erb
+++ b/app/views/contacts/show.html.erb
@@ -69,13 +69,21 @@
 
       <% if policy(Need).create? %>
         <div style="flex:1; text-align:right">
-          <%# Clicking this should display 'schedule_an_assessment as a pseudo-drop down' %>
-          Add new assessment+
-          <%# This is visible by default as a non-javascript fallback, but should be pulled into a toggleable drop down %>
-          <ul style="list-style-type: none" id="schedule_an_assessment">
+          <div class="assessment-dropdown">
+            <button id="btnAssessmentDropdown">Add new assessment +</button>
+            <div id="assessmentDropdownElements" class="assessment-dropdown-content">
+              <%= link_to('Schedule an assessment', new_contact_assessment_path(@contact.id, :type => 'schedule')) %>
+              <%= link_to('Log an assessment', new_contact_assessment_path(@contact.id, :type => 'log')) %>
+            </div>
+          </div>
+          <noscript>
+            <ul style="list-style-type: none" id="schedule_an_assessment">
             <li><%= link_to('Schedule an assessment', new_contact_assessment_path(@contact.id, :type => 'schedule')) %></li>
             <li><%= link_to('Log an assessment', new_contact_assessment_path(@contact.id, :type => 'log')) %></li>
-          </ul>
+          </ul>-->
+          </noscript>
+
+
         </div>
       <% end %>
     </header>

--- a/app/views/contacts/show.html.erb
+++ b/app/views/contacts/show.html.erb
@@ -72,14 +72,14 @@
           <div class="assessment-dropdown">
             <button id="btnAssessmentDropdown">Add new assessment +</button>
             <div id="assessmentDropdownElements" class="assessment-dropdown-content">
-              <%= link_to('Schedule an assessment', new_contact_assessment_path(@contact.id, :type => 'schedule')) %>
-              <%= link_to('Log an assessment', new_contact_assessment_path(@contact.id, :type => 'log')) %>
+              <%= link_to('Schedule an assessment', new_contact_assessment_path(@contact.id, :type => 'schedule'), id: 'schedule-assesment-btn') %>
+              <%= link_to('Log an assessment', new_contact_assessment_path(@contact.id, :type => 'log'), id: 'log-assesment-btn') %>
             </div>
           </div>
           <noscript>
             <ul style="list-style-type: none" id="schedule_an_assessment">
-            <li><%= link_to('Schedule an assessment', new_contact_assessment_path(@contact.id, :type => 'schedule')) %></li>
-            <li><%= link_to('Log an assessment', new_contact_assessment_path(@contact.id, :type => 'log')) %></li>
+            <li><%= link_to('Schedule an assessment', new_contact_assessment_path(@contact.id, :type => 'schedule'), id: 'schedule-assesment-nojs-btn') %></li>
+            <li><%= link_to('Log an assessment', new_contact_assessment_path(@contact.id, :type => 'log'), id: 'log-assesment-nojs-btn') %></li>
           </ul>-->
           </noscript>
 

--- a/features/step_definitions/assessment_steps.rb
+++ b/features/step_definitions/assessment_steps.rb
@@ -4,13 +4,13 @@ end
 
 When('I choose to schedule an assessment') do
   @assessment_type = 'schedule'
-  page.find('#assessmentDropdownElements').click
+  page.find('#btnAssessmentDropdown').click
   page.find('#schedule-assesment-btn').click
 end
 
 When('I choose to log an assessment') do
   @assessment_type = 'log'
-  page.find('#assessmentDropdownElements').click
+  page.find('#btnAssessmentDropdown').click
   page.find('#log-assesment-btn').click
 end
 

--- a/features/step_definitions/assessment_steps.rb
+++ b/features/step_definitions/assessment_steps.rb
@@ -4,12 +4,14 @@ end
 
 When('I choose to schedule an assessment') do
   @assessment_type = 'schedule'
-  click_link 'Schedule an assessment'
+  page.find('#assessmentDropdownElements').click
+  page.find('#schedule-assesment-btn').click
 end
 
 When('I choose to log an assessment') do
   @assessment_type = 'log'
-  click_link 'Log an assessment'
+  page.find('#assessmentDropdownElements').click
+  page.find('#log-assesment-btn').click
 end
 
 Then('I see the schedule assessment form') do


### PR DESCRIPTION
Background:
https://trello.com/c/Y51nfQC5/439-make-the-add-assessment-button-a-dropdown-like-the-designs

Solution:
![image](https://user-images.githubusercontent.com/63452375/80701889-cf1c3700-8ae8-11ea-922f-6f27600d52d1.png)
