### PR TITLE
Set status of "Other" needs, and set default status in DB

### DIFF
--- a/app/services/needs_creator.rb
+++ b/app/services/needs_creator.rb
@@ -11,7 +11,9 @@ class NeedsCreator
     end
 
     if other_need
-      contact.needs.build(category: 'other', name: other_need).save
+      contact.needs
+             .build(category: 'other', name: other_need, status: Need.statuses[:to_do])
+             .save
     end
   end
 

--- a/db/migrate/20200501095215_set_default_status_on_needs.rb
+++ b/db/migrate/20200501095215_set_default_status_on_needs.rb
@@ -1,0 +1,5 @@
+class SetDefaultStatusOnNeeds < ActiveRecord::Migration[6.0]
+  def change
+    change_column_default :needs, :status, from: nil, to: 'to_do'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_29_134037) do
+ActiveRecord::Schema.define(version: 2020_05_01_095215) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,7 +59,7 @@ ActiveRecord::Schema.define(version: 2020_04_29_134037) do
     t.jsonb "supplemental_data"
     t.integer "lock_version", default: 0
     t.bigint "role_id"
-    t.string "status"
+    t.string "status", default: "to_do"
     t.index ["contact_id"], name: "index_needs_on_contact_id"
     t.index ["role_id"], name: "index_needs_on_role_id"
     t.index ["status"], name: "index_needs_on_status"


### PR DESCRIPTION
Fixes bug where Other needs were not showing on a contacts profile because they had a NULL status