### PR TITLE
Assignment usability

### DIFF
--- a/app/javascript/packs/bulk-actions.js
+++ b/app/javascript/packs/bulk-actions.js
@@ -1,30 +1,33 @@
 let needs = document.querySelectorAll(".select-needs");
-let showAssignAction = false;
+let allNeeds = document.querySelector("#select-all-needs");
+const assign = document.querySelector("#assign-selected-needs");
 
-/**
- * Checkbox clicked event
- */
-let checkboxClicked = (e) => {
+for (let i = 0; i < needs.length; i++) {
+  if (needs[i].checked && assign.hasAttribute("disabled")) {
+    assign.removeAttribute('disabled');
+  }
+  needs[i].addEventListener('click', checkboxClicked)
+}
+allNeeds.addEventListener('click', selectAllNeeds)
+
+function checkboxClicked(e) {
   e.stopPropagation()
-  showAssignAction = false;
+  let checkedCount = 0;
   for (let i = 0; i < needs.length; i++) {
     if (needs[i].checked) {
-      showAssignAction = true;
-      break;
+      checkedCount++;
     }
+  }
+
+  if (checkedCount > 0) {
+    assign.removeAttribute("disabled");
+  } else {
+    assign.setAttribute("disabled", "disabled");
+    allNeeds.checked = false;
   }
 }
 
-for (let i = 0; i < needs.length; i++) {
-  needs[i].addEventListener('click', checkboxClicked)
-}
-
-let allNeeds = document.querySelector("#select-all-needs")
-
-/**
- * Select all needs
- */
-let selectAllNeeds = () => {
+function selectAllNeeds() {
   let checked;
   if(allNeeds.checked) {
     checked = true;
@@ -33,6 +36,12 @@ let selectAllNeeds = () => {
   }
   for (let i = 0; i < needs.length; i++) {
     needs[i].checked = checked;
+  }
+
+  if (checked) {
+    assign.removeAttribute("disabled");
+  } else {
+    assign.setAttribute("disabled", "disabled");
   }
 }
 
@@ -57,7 +66,7 @@ applyPatchUpdate = (for_update) => {
   });
 }
 
-allNeeds.addEventListener('click', selectAllNeeds)
+
 
 // assign to users event listener
 document.querySelector("#assign-selected-needs").addEventListener("change", (e) => {

--- a/app/views/needs/_bulk-actions.erb
+++ b/app/views/needs/_bulk-actions.erb
@@ -5,7 +5,7 @@
     <%= label_tag :assigned_to, 'Assign to', class: 'visually-hidden' %>
     <%= select_tag :assigned_to,
                    content_tag(:option,'Unassigned',:value => "Unassigned") + grouped_options_for_select(@assigned_to_options),
-                   prompt: 'Assign to...', class: "assign__needs dropdown", id: 'assign-selected-needs' %>
+                   prompt: 'Assign to...', class: "assign__needs dropdown", id: 'assign-selected-needs', disabled: 'disabled' %>
     <% if params[:user_id] || params[:status] || params[:category] || params[:is_urgent] %>
       <%= link_to "Export", url_for(params: request.query_parameters, :format => 'csv'), id: "btnExport", class: "button button--dark", "data-open" => "true" %>
     <% else %>


### PR DESCRIPTION
Background:
https://trello.com/c/zSdkJ9Go/447-assignment-usability

Solution:
- When the assign to select box is rendered, it has initially the disabled attribute applied to it.
- When the user manipulates a need checkbox, the select box will be enabled/disabled based on the count of checked needs.
- When a user un-checks all check boxes, the Assign All check box get un-checked as well. 