### PR TITLE
Change 'Are there any children under 15 living in the household?' to 'Are there any children under 18 living in the household?"

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -73,7 +73,7 @@ class ContactsController < ApplicationController
 
   def contact_params
     params.require(:contact).permit(:first_name, :middle_names, :surname, :address, :postcode, :email, :telephone,
-                                    :mobile, :additional_info, :is_vulnerable, :count_people_in_house, :any_children_below_15,
+                                    :mobile, :additional_info, :is_vulnerable, :count_people_in_house, :any_children_under_age,
                                     :delivery_details, :any_dietary_requirements, :dietary_details,
                                     :cooking_facilities, :eligible_for_free_prescriptions, :has_covid_symptoms, :lock_version,
                                     :channel, :no_calls_flag, :deceased_flag, :share_data_flag, :date_of_birth, :nhs_number)

--- a/app/controllers/triage_controller.rb
+++ b/app/controllers/triage_controller.rb
@@ -36,7 +36,7 @@ class TriageController < ApplicationController
 
   def contact_params
     params.require(:contact).permit(:first_name, :middle_names, :surname, :date_of_birth, :nhs_number, :address, :postcode, :email, :telephone,
-                                    :mobile, :additional_info, :is_vulnerable, :count_people_in_house, :any_children_below_15,
+                                    :mobile, :additional_info, :is_vulnerable, :count_people_in_house, :any_children_under_age,
                                     :delivery_details, :any_dietary_requirements, :dietary_details,
                                     :cooking_facilities, :eligible_for_free_prescriptions, :has_covid_symptoms, :lock_version,
                                     :share_data_flag, :channel)

--- a/app/views/contacts/_extra_questions.html.erb
+++ b/app/views/contacts/_extra_questions.html.erb
@@ -13,14 +13,14 @@
 </fieldset>
 
 <fieldset class="field-section field-section--two-cols">
-  <legend><h2 class="field-section__title">Any children under 15?</h2></legend>
+  <legend><h2 class="field-section__title">Are there any children under 18 living in the household?</h2></legend>
   <div class="radio">
-    <%= form.radio_button :any_children_below_15, true, :id => "any_children_below_15_true" %>
-    <label for="any_children_below_15_true" class="radio__label">Yes</label>
+    <%= form.radio_button :any_children_under_age, true, :id => "any_children_under_age_true" %>
+    <label for="any_children_under_age_true" class="radio__label">Yes</label>
   </div>
   <div class="radio">
-    <%= form.radio_button :any_children_below_15, false, :id => "any_children_below_15_false" %>
-    <label for="any_children_below_15_false" class="radio__label">No</label>
+    <%= form.radio_button :any_children_under_age, false, :id => "any_children_under_age_false" %>
+    <label for="any_children_under_age_false" class="radio__label">No</label>
   </div>
 </fieldset>
 

--- a/app/views/shared/_profile-accordion-edit.html.erb
+++ b/app/views/shared/_profile-accordion-edit.html.erb
@@ -65,8 +65,8 @@
     </dl>
 
     <div class="checkbox">
-      <%= form.check_box :any_children_below_15, class: 'checkbox__input', checked: @contact.any_children_below_15 == '1' %>
-      <%= form.label :any_children_below_15, 'Any children under 15?', class: 'checkbox__label' %>
+      <%= form.check_box :any_children_under_age, class: 'checkbox__input', checked: @contact.any_children_under_age == '1' %>
+      <%= form.label :any_children_under_age, 'Any children under 18?', class: 'checkbox__label' %>
     </div>
   </div>
 

--- a/app/views/shared/_profile-accordion.html.erb
+++ b/app/views/shared/_profile-accordion.html.erb
@@ -42,7 +42,7 @@
             <dt class="details-list__caption">Number of people living there</dt>
             <dd class="details-list__value" id="count_people_in_house"><%= dash_if_empty @contact.count_people_in_house %></dd>
 
-            <dt class="details-list__caption">Living with people under 15</dt>
+            <dt class="details-list__caption">Living with people under 18</dt>
             <dd class="details-list__value" id="any_children_under_age"><%= friendly_boolean @contact.any_children_under_age %></dd>
         </dl>
     </div>

--- a/app/views/shared/_profile-accordion.html.erb
+++ b/app/views/shared/_profile-accordion.html.erb
@@ -43,7 +43,7 @@
             <dd class="details-list__value" id="count_people_in_house"><%= dash_if_empty @contact.count_people_in_house %></dd>
 
             <dt class="details-list__caption">Living with people under 15</dt>
-            <dd class="details-list__value" id="any_children_below_15"><%= friendly_boolean @contact.any_children_below_15 %></dd>
+            <dd class="details-list__value" id="any_children_under_age"><%= friendly_boolean @contact.any_children_under_age %></dd>
         </dl>
     </div>
 

--- a/db/migrate/20200504123442_rename_fifteen_to_age_contacts.rb
+++ b/db/migrate/20200504123442_rename_fifteen_to_age_contacts.rb
@@ -1,0 +1,6 @@
+class RenameFifteenToAgeContacts < ActiveRecord::Migration[6.0]
+  StrongMigrations.disable_check(:rename_column)
+  def change
+    rename_column :contacts, :any_children_below_15, :any_children_under_age
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_01_133906) do
+ActiveRecord::Schema.define(version: 2020_05_04_123442) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,7 +30,7 @@ ActiveRecord::Schema.define(version: 2020_05_01_133906) do
     t.text "email"
     t.string "additional_info"
     t.integer "count_people_in_house"
-    t.boolean "any_children_below_15"
+    t.boolean "any_children_under_age"
     t.text "delivery_details"
     t.boolean "any_dietary_requirements"
     t.text "dietary_details"

--- a/features/step_definitions/person_steps.rb
+++ b/features/step_definitions/person_steps.rb
@@ -110,9 +110,9 @@ end
 
 When('I choose {string} for any children under 15') do |option|
   if option == 'Yes'
-    check 'contact_any_children_below_15'
+    check 'contact_any_children_under_age'
   else
-    uncheck 'contact_any_children_below_15'
+    uncheck 'contact_any_children_under_age'
   end
 end
 
@@ -160,7 +160,7 @@ Then('the dietary details is {string}') do |details|
 end
 
 Then('the children under 15 details are {string}') do |details|
-  expect(page.find_by_id('any_children_below_15')).to have_text(details)
+  expect(page.find_by_id('any_children_under_age')).to have_text(details)
 end
 
 Then('eligible for free prescriptions is {string}') do |details|

--- a/spec/factories/contacts.rb
+++ b/spec/factories/contacts.rb
@@ -12,7 +12,7 @@ FactoryBot.define do
     is_vulnerable { Faker::Boolean.boolean(true_ratio: 0.3) }
     additional_info {}
     count_people_in_house { [Faker::Number.between(from: 0, to: 6), nil].sample }
-    any_children_below_15 { Faker::Boolean.boolean(true_ratio: 0.2) }
+    any_children_under_age { Faker::Boolean.boolean(true_ratio: 0.2) }
     delivery_details { Faker::Lorem.sentence }
     any_dietary_requirements { Faker::Boolean.boolean(true_ratio: 0.2) }
     dietary_details { Faker::Lorem.sentence }


### PR DESCRIPTION
Background:
https://trello.com/c/0xiu8v2U/81-change-are-there-any-children-under-15-living-in-the-household-to-are-there-any-children-under-18-living-in-the-household

Solution:
- Renamed labels in the UI, variables in the back-end and table column. 