### PR TITLE
BugFix: Food manager receives error

### DIFF
--- a/app/policies/need_policy.rb
+++ b/app/policies/need_policy.rb
@@ -20,7 +20,6 @@ class NeedPolicy < ApplicationPolicy
       @scope.includes(:role)
             .where(roles: { tag: role_tag })
             .or(Need.includes(:role).where(user: @user))
-            .distinct
     end
 
     def needs_me_role_team(role_tag)
@@ -28,7 +27,6 @@ class NeedPolicy < ApplicationPolicy
             .where(roles: { tag: role_tag })
             .or(Need.includes(:role, user: [:roles]).where(user: @user))
             .or(Need.includes(:role, user: [:roles]).where("roles_users.role = '#{role_tag}'"))
-            .distinct
     end
   end
 

--- a/app/policies/need_policy.rb
+++ b/app/policies/need_policy.rb
@@ -17,16 +17,16 @@ class NeedPolicy < ApplicationPolicy
     end
 
     def needs_me_or_role(role_tag)
-      @scope.includes(:role)
+      @scope.where(id: Need.includes(:role)
             .where(roles: { tag: role_tag })
-            .or(Need.includes(:role).where(user: @user))
+            .or(Need.includes(:role).where(user: @user)))
     end
 
     def needs_me_role_team(role_tag)
-      @scope.includes(:role, user: [:roles])
-            .where(roles: { tag: role_tag })
-            .or(Need.includes(:role, user: [:roles]).where(user: @user))
-            .or(Need.includes(:role, user: [:roles]).where("roles_users.role = '#{role_tag}'"))
+      @scope.where(id: Need.includes(:role, user: [:roles])
+                           .where(roles: { tag: role_tag })
+                           .or(Need.includes(:role, user: [:roles]).where(user: @user))
+                           .or(Need.includes(:role, user: [:roles]).where("roles_users.role = '#{role_tag}'")))
     end
   end
 


### PR DESCRIPTION
An explanation of the issue:
There are three 'mutations' of the active record query that get performed.
1. The policy scope, which limits the records a user can see to those assigned to the right teams/users
2. The aggregations, which add extra calculated fields from subqueries
3. The filter/sort

Given that there is a fairly complex interplay between these queries, the simplest solution is to take the policy queries, and move them into a `where in (subquery)` query.  This means that the sorting issues - caused by a mismatch of distinct/aggregate columns, should be fixed, and the overall SQL structure is easier to understand.