### PR TITLE
Remove 'Priority 3' as an option for food priority

### DIFF
--- a/app/views/triage/_groceries_and_cooked_meals.html.erb
+++ b/app/views/triage/_groceries_and_cooked_meals.html.erb
@@ -9,11 +9,7 @@
     <%= need_form.radio_button :food_priority, '2', checked: need['food_priority'] == '2' %>
     <%= need_form.label :food_priority_2, 'Priority 2', class: 'radio__label' %>
   </div>
-  <div class="radio">
-    <%= need_form.radio_button :food_priority, '3', checked: need['food_priority'] == '3' %>
-    <%= need_form.label :food_priority_3, 'Priority 3', class: 'radio__label' %>
-  </div>
-
+  
 </fieldset>
 
 <fieldset class="field-section field-section--two-cols">


### PR DESCRIPTION
Background:
https://trello.com/c/YKsWJNH3/82-remove-priority-3-as-an-option-for-food-priorty

Solution:
- Removed the priority 3 radio button

- Need to create cleanup script for Priority 3 needs in the db