### PR TITLE
Feature/103 table to show needs ive created but left unassigned

### DIFF
--- a/app/controllers/needs_controller.rb
+++ b/app/controllers/needs_controller.rb
@@ -18,7 +18,7 @@ class NeedsController < ApplicationController
              else
                @assigned_to_options = construct_assigned_to_options
                policy_scope(Need).started
-    end
+             end
 
     @needs = @needs.filter_and_sort(@params.slice(:category, :assigned_to, :status, :is_urgent), @params.slice(:order, :order_dir))
     @needs = @needs.page(params[:page]) unless request.format == 'csv'

--- a/app/controllers/needs_controller.rb
+++ b/app/controllers/needs_controller.rb
@@ -9,9 +9,6 @@ class NeedsController < ApplicationController
 
   def index
     @params = params.permit(:assigned_to, :status, :category, :page, :order_dir, :order, :commit, :is_urgent, :created_by_me)
-    @users = User.all
-    @roles = Role.all
-
     @needs = if @params[:created_by_me] == 'true'
                @assigned_to_options = {}
                Need.created_by(current_user.id).filter_by_assigned_to('Unassigned')
@@ -33,8 +30,6 @@ class NeedsController < ApplicationController
 
   def deleted_needs
     @params = params.permit(:category, :page, :order_dir, :order, :commit, :deleted_at)
-    @users = User.all
-    @roles = Role.all
     @needs = policy_scope(Need).deleted
                                .filter_and_sort(@params.slice(:category, :deleted_at), @params.slice(:order, :order_dir))
     @needs = @needs.page(params[:page])
@@ -42,8 +37,6 @@ class NeedsController < ApplicationController
 
   def deleted_notes
     @params = params.permit(:category, :page, :order_dir, :order, :commit, :deleted_at)
-    @users = User.all
-    @roles = Role.all
     @notes = policy_scope(Note).deleted
                                .filter_need_not_destroyed
                                .filter_and_sort(@params.slice(:category, :deleted_at), @params.slice(:order, :order_dir))
@@ -70,8 +63,6 @@ class NeedsController < ApplicationController
   end
 
   def edit
-    @roles = Role.all
-    @users = User.all
     @delete_prompt = get_delete_prompt @need
   end
 

--- a/app/views/needs/_filters.html.erb
+++ b/app/views/needs/_filters.html.erb
@@ -13,6 +13,9 @@
   <% end %>
       <%= form_with(url: root_path, method: :get, local: true, class: "filters__form") do %>
         <label for="assigned_to" class="visually-hidden">By assigned user or team</label>
+        <% if params[:created_by_me] == 'true' %>
+          <%= hidden_field_tag('created_by_me', 'true') %>
+        <% end %>
         <%= select_tag("assigned_to",
             content_tag(:option,'Unassigned',:value => "Unassigned", :selected => params["assigned_to"] == "Unassigned") + grouped_options_for_select(@assigned_to_options, params['assigned_to']), prompt: 'All users/teams', class: "filters__select dropdown") %>
 

--- a/app/views/shared/_side-nav.html.erb
+++ b/app/views/shared/_side-nav.html.erb
@@ -40,6 +40,10 @@
                 <span class="main-menu__submenu-current">Team Completed</span>
               <% end %>
             <% end %>
+
+            <%= link_to_unless_current "Created & Unassigned", root_path(:created_by_me => 'true'), class: "main-menu__submenu-link" do %>
+              <span class="main-menu__submenu-current">Created & Unassigned</span>
+            <% end %>
           </ul>
         </li>
 

--- a/app/views/shared/_side-nav.html.erb
+++ b/app/views/shared/_side-nav.html.erb
@@ -41,8 +41,10 @@
               <% end %>
             <% end %>
 
-            <%= link_to_unless_current "Created & Unassigned", root_path(:created_by_me => 'true'), class: "main-menu__submenu-link" do %>
-              <span class="main-menu__submenu-current">Created & Unassigned</span>
+            <% if policy(Need).create? %>
+              <%= link_to_unless_current "Created & Unassigned", root_path(:created_by_me => 'true'), class: "main-menu__submenu-link" do %>
+                <span class="main-menu__submenu-current">Created & Unassigned</span>
+              <% end %>
             <% end %>
           </ul>
         </li>

--- a/features/list_support_actions.feature
+++ b/features/list_support_actions.feature
@@ -49,17 +49,13 @@ Feature: List support actions
     Then I see the support action for category "Groceries and cooked meals" first in the results
 
   Scenario: See unassigned needs I have created in the created and unassigned list
-    Given a unique resident
-    And I add support actions "Dog walking"
-    And I submit the add support actions form
+    Given I have created a support action "Dog walking"
     When I go the the created and unassigned support action list
     Then I see the support action for category "Dog walking" in the results
 
   @javascript
   Scenario: Do not see assigned needs I have created in the created and unassigned list
-    Given a unique resident
-    And I add support actions "Dog walking"
-    And I submit the add support actions form
+    Given I have created a support action "Dog walking"
     And I assign the support action to another user
     When I go the the created and unassigned support action list
     Then I can not see that support action in the list

--- a/features/list_support_actions.feature
+++ b/features/list_support_actions.feature
@@ -47,3 +47,18 @@ Feature: List support actions
     Given a resident with "Book drops and entertainment, Dog walking, Groceries and cooked meals" support actions
     When I sort support actions by category in "DESC" order
     Then I see the support action for category "Groceries and cooked meals" first in the results
+
+  Scenario: See unassigned needs I have created in the created and unassigned list
+    Given a unique resident
+    And I add support actions "Dog walking"
+    And I submit the add support actions form
+    When I go the the created and unassigned support action list
+    Then I see the support action for category "Dog walking" in the results
+
+  Scenario: Do not see assigned needs I have created in the created and unassigned list
+    Given a unique resident
+    And I add support actions "Dog walking"
+    And I submit the add support actions form
+    And I assign the support action to another user
+    When I go the the created and unassigned support action list
+    Then I can not see that support action in the list

--- a/features/list_support_actions.feature
+++ b/features/list_support_actions.feature
@@ -55,6 +55,7 @@ Feature: List support actions
     When I go the the created and unassigned support action list
     Then I see the support action for category "Dog walking" in the results
 
+  @javascript
   Scenario: Do not see assigned needs I have created in the created and unassigned list
     Given a unique resident
     And I add support actions "Dog walking"

--- a/features/step_definitions/support_action_steps.rb
+++ b/features/step_definitions/support_action_steps.rb
@@ -1,3 +1,9 @@
+Given('I have created a support action {string}') do |support_action|
+  step 'a unique resident'
+  step "I add support actions \"#{support_action}\""
+  step 'I submit the add support actions form'
+end
+
 When('I add support actions {string}') do |support_action|
   visit "/contacts/#{@contact.id}"
   click_link 'Add support actions'

--- a/features/step_definitions/support_action_steps.rb
+++ b/features/step_definitions/support_action_steps.rb
@@ -25,6 +25,7 @@ end
 
 And('I submit the add support actions form') do
   click_button('Save changes')
+  @need = Need.order(:created_at).last
 end
 
 Then('I see an error message {string}') do |error|

--- a/features/step_definitions/support_actions_list_steps.rb
+++ b/features/step_definitions/support_actions_list_steps.rb
@@ -36,6 +36,10 @@ When('I sort support actions by category in {string} order') do |order|
   visit "/?order=category&order_dir=#{order}&page=1"
 end
 
+When('I go the the created and unassigned support action list') do
+  visit '/?created_by_me=true'
+end
+
 Then('I see the support action for category {string} first in the results') do |category|
   first_row = page.find('table > tbody > tr:nth-child(1)')
   category_column = first_row.find('td:nth-child(2)')


### PR DESCRIPTION
Currently this is implemented as another dashboard link in the sidebar
![Screenshot from 2020-05-12 09-50-42](https://user-images.githubusercontent.com/4345596/81662892-1afaa480-9436-11ea-9b83-3fde8d98e3e7.png)
There are designs that display this embedded in a page, but as it is part of a wider dashboard redesign, that seems better left until those are finalized