### PR TITLE
Fix completed needs js error

### DIFF
--- a/app/javascript/packs/completed-needs.js
+++ b/app/javascript/packs/completed-needs.js
@@ -10,7 +10,7 @@ let toShowCompletedNeeds = false;
 const toggleDisplayCompletedNeeds = (show) => show ? 'table-row' : 'none';
 
 const toggleVisibilityCompletedNeeds = document.getElementById('toggle-visibility-completed-needs')
-toggleVisibilityCompletedNeeds.addEventListener('click', (e) => {
+toggleVisibilityCompletedNeeds && toggleVisibilityCompletedNeeds.addEventListener('click', (e) => {
   toShowCompletedNeeds = !toShowCompletedNeeds;
   const table = toggleVisibilityCompletedNeeds.parentNode.parentNode
   if(toShowCompletedNeeds) {


### PR DESCRIPTION
When we dont have completed needs we dont have element for them. In this case we can not add event listener to the element.