### PR TITLE
Inconsistent styling on the final header of the assessment form, 'completion'

### DIFF
--- a/app/views/assessments/complete.html.erb
+++ b/app/views/assessments/complete.html.erb
@@ -10,7 +10,7 @@
     <%= form_with model: @completion_form, url: update_completion_assessment_path, :method => :put,
                   :local => true, :html => {:name => 'assessment_completion_form', :autocomplete => 'off'} do |form| %>
       <div class="panel panel--unpadded panel--stroked need--phone-triage">
-        <%= link_to "Complete #{@assessment.category.humanize}", assign_assessment_path(@assessment.id), class: "panel__header" %>
+        <%= link_to "Complete #{@assessment.category.humanize}", assign_assessment_path(@assessment.id), class: "panel__header-with-arrow" %>
         <div class="assessment-complete-progress-container">
           <%= render :partial => 'shared/progress-wizard', locals: {state: [1, 1, 1, 2]} %>
         </div>


### PR DESCRIPTION
Background:
https://trello.com/c/OKqXslp4/151-inconsistent-styling-on-the-final-header-of-the-assessment-form-completion

Solution:
- Changed panel header class to contain left arrow