### PR TITLE
Added Go to page functionality

### DIFF
--- a/app/assets/stylesheets/pagination.scss
+++ b/app/assets/stylesheets/pagination.scss
@@ -1,5 +1,43 @@
 @import "variables";
 
+.pagination-records-summary, .pagination-page-selection {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+}
+
+.pagination-page-selection {
+  * {
+    margin-left: 10px;
+  }
+
+  a {
+    &.button {
+      min-width: 40px;
+      width: 40px;
+      height: 20px;
+      margin-right: 0;
+      padding-top: 0;
+      &.disabled {
+        opacity: 0.5;
+        pointer-events: none;
+      }
+    }
+  }
+
+  .page-select {
+    width: 40px;
+    height: 40px;
+    border: 1px solid $text;
+    font-size: 0.9rem;
+    background: white;
+    &:focus {
+      border-color: inherit;
+      background: inherit;
+    }
+  }
+}
+
 .pagination{
     display: flex;
     flex-direction: row;

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -45,4 +45,10 @@ module ApplicationHelper
       ''
     end
   end
+
+  def displayed_items_count(model, page_number)
+    expected_elements_count = model.total_count - (page_number.to_i - 1) * model.default_per_page
+
+    expected_elements_count < model.default_per_page ? expected_elements_count : model.default_per_page
+  end
 end

--- a/app/javascript/packs/pagination.js
+++ b/app/javascript/packs/pagination.js
@@ -1,0 +1,36 @@
+$(document).ready(() => {
+    const pageSelect = $(".page-select");
+    pageSelect.val("");
+
+    const link = $("a.button.button--blue");
+    link.addClass("disabled");
+
+    const pageInQueryStringRegex = /page=\d+/;
+    const hasQueryStringRegex = /[?&]/;
+
+    pageSelect.keyup((event) => {
+       if (event.currentTarget.value && event.currentTarget.validity.valid) {
+           link.removeClass("disabled");
+       } else {
+           link.addClass("disabled");
+       }
+    });
+
+    link.click(() => {
+        const pageValue = +pageSelect.val();
+        if (!pageValue) {
+            return;
+        }
+
+        let currentHref = window.location.href;
+        if (pageInQueryStringRegex.test(currentHref)) {
+            currentHref = currentHref.replace(pageInQueryStringRegex, `page=${pageValue}`);
+
+        } else {
+            let separator = hasQueryStringRegex.test(currentHref)
+                ? '&' : '?';
+            currentHref = `${currentHref}${separator}page=${pageValue}`
+        }
+        link.attr("href", currentHref);
+    });
+});

--- a/app/views/shared/_pagination.html.erb
+++ b/app/views/shared/_pagination.html.erb
@@ -1,5 +1,7 @@
+<div class="pagination-records-summary">
+  Displaying <%= displayed_items_count(model, params[:page]) %> out of <%= model.total_count %> records
+</div>
 <nav class="pagination">
-
     <p>Page <strong><%= params[:page] || "1" %></strong> of <strong><%= model.total_pages %></strong></p>
 
     <% if previous_page_url(model) %>
@@ -23,3 +25,10 @@
         </div>
     <% end %>
 </nav>
+<div class="pagination-page-selection">
+  <label for="txtPage">Go to page:</label>
+  <input id="txtPage" type="text" class="page-select" pattern="[0-9]+" />
+  <%= link_to 'Go', '', class: 'button button--blue' %>
+</div>
+
+<%= javascript_pack_tag 'pagination' %>


### PR DESCRIPTION
Background:
https://trello.com/b/UE2qyYpg/beacon-platform-4th-may-3rd-june

Solution:
- Added a text field for entering a page number and a link next to it, to perform the navigation.
If the field is empty or contains invalid input, the link is disabled.