### PR TITLE
Make radio buttons slightly smaller

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -101,9 +101,9 @@ textarea{
 
 .radio{
     position: relative;
-    padding: 10px 0px 10px 50px;
+    padding: 10px 0 10px 50px;
     &:focus-within label:before{
-      box-shadow: 0px 0px 0px 2px $yellow;
+      box-shadow: 0 0 0 2px $yellow;
     }
     input{
       font-size: 2rem;
@@ -111,8 +111,8 @@ textarea{
       width:35px;
       height:35px;
       position: absolute;
-      left: 0px;
-      top: 0px;
+      left: 0;
+      top: 0;
       &:checked + label:after{
         position: absolute;
         content: "";
@@ -137,8 +137,27 @@ textarea{
         border-radius: 100%;
         height: 35px;
         position: absolute;
-        left: 0px;
-        top: 0px;
+        left: 0;
+        top: 0;
+      }
+    }
+    &.radio-spacing-small {
+      padding-top: 2px;
+      padding-bottom: 20px;
+      padding-left: 35px;
+      input {
+        width: 0;
+        height: 0;
+        &:checked + label:after {
+          width: 12px;
+          height: 12px;
+        }
+      }
+      .radio__label {
+        &:before {
+          width: 20px;
+          height: 20px;
+        }
       }
     }
 }

--- a/app/views/assessments/_groceries_and_cooked_meals.html.erb
+++ b/app/views/assessments/_groceries_and_cooked_meals.html.erb
@@ -1,11 +1,11 @@
 <fieldset class="field-section field-section--two-cols">
   <legend><h3 class="field-section__title">Food requirements priority</h3></legend>
 
-  <div class="radio">
+  <div class="radio radio-spacing-small">
     <%= need_form.radio_button :food_priority, '1', checked: need[:food_priority] == '1' %>
     <%= need_form.label :food_priority_1, 'Priority 1', class: 'radio__label' %>
   </div>
-  <div class="radio">
+  <div class="radio radio-spacing-small">
     <%= need_form.radio_button :food_priority, '2', checked: need[:food_priority] == '2' %>
     <%= need_form.label :food_priority_2, 'Priority 2', class: 'radio__label' %>
   </div>
@@ -15,15 +15,15 @@
 <fieldset class="field-section field-section--two-cols">
   <legend><h3 class="field-section__title">Which type of food service?</h3></legend>
 
-  <div class="radio">
+  <div class="radio radio-spacing-small">
     <%= need_form.radio_button :food_service_type, 'Hot meal', checked: need[:food_service_type] == 'Hot meal' %>
     <%= need_form.label :food_service_type_hot_meal, 'Hot meal', class: 'radio__label' %>
   </div>
-  <div class="radio">
+  <div class="radio radio-spacing-small">
     <%= need_form.radio_button :food_service_type, 'Heat up', checked: need[:food_service_type] == 'Heat up' %>
     <%= need_form.label :food_service_type_heat_up, 'Heat up', class: 'radio__label' %>
   </div>
-  <div class="radio">
+  <div class="radio radio-spacing-small">
     <%= need_form.radio_button :food_service_type, 'Grocery delivery', checked: need[:food_service_type] == 'Grocery delivery' %>
     <%= need_form.label :food_service_type_grocery_delivery, 'Grocery delivery', class: 'radio__label' %>
   </div>
@@ -35,11 +35,11 @@
 
 
   <fieldset class="field-section field-section--two-cols">
-    <div class="radio">
+    <div class="radio radio-spacing-small">
       <%= form.radio_button :any_dietary_requirements, true, :id => "any_dietary_requirements_true" %>
       <label for="any_dietary_requirements_true" class="radio__label">Yes</label>
     </div>
-    <div class="radio">
+    <div class="radio radio-spacing-small">
       <%= form.radio_button :any_dietary_requirements, false, :id => "any_dietary_requirements_false" %>
       <label for="any_dietary_requirements_false" class="radio__label">No</label>
     </div>

--- a/app/views/assessments/_prescription_pickups.html.erb
+++ b/app/views/assessments/_prescription_pickups.html.erb
@@ -1,11 +1,11 @@
 <fieldset class="field-section field-section--two-cols">
   <legend><h3 class="field-section__title">Are they eligible for free prescriptions?</h3></legend>
   
-  <div class="radio">
+  <div class="radio radio-spacing-small">
     <%= form.radio_button :eligible_for_free_prescriptions, true, :id => "eligible_for_free_prescriptions_true" %>
     <label for="eligible_for_free_prescriptions_true" class="radio__label">Yes</label>
   </div>
-  <div class="radio">
+  <div class="radio radio-spacing-small">
     <%= form.radio_button :eligible_for_free_prescriptions, false, :id => "eligible_for_free_prescriptions_false" %>
     <label for="eligible_for_free_prescriptions_false" class="radio__label">No</label>
   </div>

--- a/app/views/assessments/complete.html.erb
+++ b/app/views/assessments/complete.html.erb
@@ -29,7 +29,7 @@
           <div class="field">
             <h3>How did you complete the <%= @assessment.category.humanize %>?</h3>
             <% assessment_completion_methods.each do |completion_method, description| %>
-              <div class="radio">
+              <div class="radio radio-spacing-small">
                 <%= form.radio_button :completion_method, completion_method %>
                 <%= form.label "completion_method_#{completion_method.downcase}", description, :class => 'radio__label' %>
               </div>

--- a/app/views/assessments/fail.html.erb
+++ b/app/views/assessments/fail.html.erb
@@ -37,7 +37,7 @@
         <div class="field">
           <h3>Why wasn't the check in call successful?</h3>
           <% assessment_failure_reasons.each do |failure_reason, description| %>
-            <div class="radio">
+            <div class="radio radio-spacing-small">
               <%= form.radio_button :failure_reason, failure_reason %>
               <%= form.label "failure_reason_#{failure_reason.downcase}", description, :class => 'radio__label' %>
             </div>
@@ -47,7 +47,7 @@
         <div id="left_message_question_section" class="field" hidden="hidden">
           <h3>Did you leave a message?</h3>
           <% %w(Yes No).each do |message_choice| %>
-            <div class="radio">
+            <div class="radio radio-spacing-small">
               <%= form.radio_button :left_message, message_choice %>
               <%= form.label :"left_message_#{message_choice.downcase}", message_choice, :class => 'radio__label' %>
             </div>

--- a/app/views/needs/_notes.html.erb
+++ b/app/views/needs/_notes.html.erb
@@ -7,7 +7,7 @@
         <%= form.label :category, 'Choose a category', class: "field__label" %>
       </legend>
       <% Note.categories_without_phone_import.each.with_index do |nc, index| %>
-        <div class="radio">
+        <div class="radio radio-spacing-small">
           <% field_value = "category_#{note_category_form_id(nc)}"  %>
           <%= form.radio_button :category, note_category_form_id(nc), :id => field_value, :checked => index == 0 %>
           <label for=<%= field_value %> class="radio__label"><%= note_category_form_display(nc) %></label>


### PR DESCRIPTION
Background:
https://trello.com/c/Uqpfsa8x/169-make-radio-buttons-slightly-smaller-space-between-options

Solution:
- Introduced another css class for smaller radio buttons.