### PR TITLE
Change 'complete assessment' to 'complete'

### DIFF
--- a/app/views/assessments/complete.html.erb
+++ b/app/views/assessments/complete.html.erb
@@ -105,7 +105,7 @@
           </div>
         </div>
       <% end %>
-      <input type="submit" value="Complete assessment" class="button button--primary" style="float: right"/>
+      <input type="submit" value="Complete" class="button button--primary" style="float: right"/>
     <% end %>
   </aside>
 </div>

--- a/features/step_definitions/assessments/complete_assessment_steps.rb
+++ b/features/step_definitions/assessments/complete_assessment_steps.rb
@@ -39,7 +39,7 @@ Then('I should see the date of the next check in') do
 end
 
 When('I complete the assessment') do
-  click_link_or_button 'Complete assessment'
+  click_link_or_button 'Complete'
 end
 
 When('I schedule a check in for tomorrow') do


### PR DESCRIPTION
Task: https://trello.com/c/I7FmwXcA/172-remove-assessment-from-assessment-completion-final-submit-button-should-just-say-complete