### PR TITLE
Increase login link timeout

### DIFF
--- a/config/initializers/passwordless.rb
+++ b/config/initializers/passwordless.rb
@@ -2,5 +2,5 @@ config = Rails.configuration.councils[ENV['COUNCIL'] || :demo]
 Passwordless.default_from_address =  config[:default_from_address]
 # Passwordless.restrict_token_reuse = true
 Passwordless.expires_at = lambda { 1.day.from_now } # How long until a passwordless session expires.
-expiry_minutes = ENV['LINK_EXPIRY_MINUTES'] || 10
+expiry_minutes = 30 # ENV['LINK_EXPIRY_MINUTES'] || 10
 Passwordless.timeout_at = lambda { expiry_minutes.to_i.minutes.from_now } # How long until a magic link expires.


### PR DESCRIPTION
This is a temporary solution. 
@userman123 please validate the `ENV['LINK_EXPIRY_MINUTES']` value and how we can control it.