### PR TITLE
Containerising the app for development

### DIFF
--- a/.github/workflows/run_spec_tests.yml
+++ b/.github/workflows/run_spec_tests.yml
@@ -9,47 +9,11 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-18.04
-
-    services:
-      postgres:
-        image: postgres:11.7-alpine
-        env:
-          POSTGRES_USER: test_local_user
-          POSTGRES_PASSWORD: password
-          POSTGRES_DB: i_have_i_need_test
-        ports:
-          - 5432:5432
-        # needed because the postgres container does not provide a healthcheck
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Ruby 2.5.8
-      uses: actions/setup-ruby@v1
-      with:
-        ruby-version: 2.5.8
-    - name: Ruby gem cache
-      uses: actions/cache@v1
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gems1-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-gems1-
-    - name: Install gems
-      run: |
-        gem install bundler
-        bundle config path vendor/bundle
-        bundle install --jobs 4 --retry 3
     - name: Setup database
-      env:
-        RAILS_ENV: test
-      run: |
-        bundle exec rails db:drop
-        bundle exec rails db:create
-        bundle exec rails db:migrate
-        bundle exec rails db:seed
+      run: docker-compose run -e RAILS_ENV=test app rails db:create db:migrate
     - name: Run tests
-      run: |
-        bundle exec rspec
+      run: docker-compose run -e RAILS_ENV=test app rspec

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -3,14 +3,12 @@ FROM ruby:2.5.8
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 RUN apt-get update -qq && apt-get remove cmdtest && apt-get install -y nodejs postgresql-client yarn
-RUN gem install bundler
+RUN gem install bundler -v 2.1.4
 ENV RAILS_ENV development
 ENV DATABASE_HOST postgresql
 WORKDIR /app
-COPY Gemfile /app/Gemfile
-COPY Gemfile.lock /app/Gemfile.lock
-COPY package.json /app/package.json
-COPY yarn.lock /app/yarn.lock
+COPY Gemfile Gemfile.lock /app/
+COPY package.json yarn.lock /app/
 
 RUN bundle
 RUN yarn install --check-files

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,23 @@
+FROM ruby:2.5.8
+
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+RUN apt-get update -qq && apt-get remove cmdtest && apt-get install -y nodejs postgresql-client yarn
+RUN gem install bundler
+ENV RAILS_ENV development
+ENV DATABASE_HOST postgresql
+WORKDIR /app
+COPY Gemfile /app/Gemfile
+COPY Gemfile.lock /app/Gemfile.lock
+COPY package.json /app/package.json
+COPY yarn.lock /app/yarn.lock
+
+RUN bundle
+RUN yarn install --check-files
+COPY . /app
+COPY entrypoint.sh /usr/bin/
+RUN chmod +x /usr/bin/entrypoint.sh
+ENTRYPOINT ["entrypoint.sh"]
+EXPOSE 3000
+
+CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -24,6 +24,20 @@ It deals in:
 
 It's a rails app backed by a postgresql database.
 
+## Running with Docker Compose
+
+Spin up a postgres database and rails app
+
+```
+docker-compose up
+```
+
+Run tests
+
+```
+docker-compose run app rake
+```
+
 ## Running it locally
 
 ```

--- a/config/database.yml
+++ b/config/database.yml
@@ -7,13 +7,15 @@ default: &default
 
 development:
   <<: *default
-  url: postgresql://localhost/i_have_i_need_development
+  host: <%= ENV.fetch('DATABASE_HOST', 'localhost') %>
+  database: i_have_i_need_development
   username: dev_local_user
   password: password
 
 test:
   <<: *default
-  url: postgresql://localhost/i_have_i_need_test
+  host: <%= ENV.fetch('DATABASE_HOST', 'localhost') %>
+  database: i_have_i_need_test
   username: test_local_user
   password: password
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -72,4 +72,7 @@ Rails.application.configure do
       :authentication => :plain,
       :enable_starttls_auto => false
   }
+
+  # Allow console to connect from docker
+  config.web_console.whitelisted_ips = ['172.29.0.0/16', '127.0.0.1']
 end

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -80,6 +80,8 @@ test:
   <<: *default
   compile: true
 
+  check_yarn_integrity: false
+
   # Compile test packs to a separate directory
   public_output_path: packs-test
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,19 @@ services:
     image: postgres:11.7-alpine
     volumes:
       - ./docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
-    ports:
-      - "5432:5432"
     environment:
       POSTGRES_DB: i_have_i_need_development
       POSTGRES_USER: dev_local_user
       POSTGRES_PASSWORD: password
+
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    command: bash -c "rm -f tmp/pids/server.pif && bundle exec rails s -p 3000 -b '0.0.0.0'"
+    volumes:
+      - .:/app
+    ports:
+      - "3000:3000"
+    depends_on:
+      - postgresql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.dev
-    command: bash -c "rm -f tmp/pids/server.pif && bundle exec rails s -p 3000 -b '0.0.0.0'"
     volumes:
       - .:/app
     ports:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+# Remove a potentially pre-existing server.pid for Rails.
+rm -f /app/tmp/pids/server.pid
+
+# Then exec the container's main process (what's set as CMD in the Dockerfile).
+exec "$@"


### PR DESCRIPTION
This ought to work for local / docker-compose development now. The only thing I needed to change was turn off yarn integrity check in the test environment, seemed like an ok-ish workaround for now.