### PR TITLE
Strip whitespace from all AR attributes that respond_to strip - Contacts model

### DIFF
--- a/app/models/concerns/clean_data.rb
+++ b/app/models/concerns/clean_data.rb
@@ -3,7 +3,25 @@
 module CleanData
   extend ActiveSupport::Concern
 
-  def strip_whitespace
+  # Strip Leading and Trailing Whitespace from text and string fields
+  # Include on an ApplicationRecord object via:
+  # 'include CleanData'
+  module ClassMethods
+    # If only would like to strip whitespace from specific attributes/fields
+    # 'trim_fields :first_name, :middle_names, :surname'
+    def trim_fields(*field_list)
+      before_validation do
+        field_list.each do |field|
+          send("#{field}=", send(field).strip) if send(field).respond_to?('strip')
+        end
+      end
+    end
+  end
+
+  # Strip on all model attributes/fields:
+  # 'before_validate :strip_whitespace_from_all_text_and_strings'
+  # 'before_save :strip_whitespace_from_all_text_and_strings'
+  def strip_whitespace_from_all_text_and_strings
     attributes.each do |name, value|
       send("#{name}=", send(name).strip) if value.respond_to?(:strip)
     end

--- a/app/models/concerns/clean_data.rb
+++ b/app/models/concerns/clean_data.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module CleanData
+  extend ActiveSupport::Concern
+
+  def strip_whitespace
+    attributes.each do |name, value|
+      send("#{name}=", send(name).strip) if value.respond_to?(:strip)
+    end
+  end
+end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -5,7 +5,7 @@ class Contact < ApplicationRecord
   require 'activerecord-import/active_record/adapters/postgresql_adapter'
   include CleanData
 
-  before_save :strip_whitespace
+  before_validation :strip_whitespace_from_all_text_and_strings
 
   has_many :needs, dependent: :destroy
   has_many :uncompleted_needs, -> { uncompleted }, class_name: 'Need'

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -3,6 +3,9 @@
 class Contact < ApplicationRecord
   require 'activerecord-import/base'
   require 'activerecord-import/active_record/adapters/postgresql_adapter'
+  include CleanData
+
+  before_save :strip_whitespace
 
   has_many :needs, dependent: :destroy
   has_many :uncompleted_needs, -> { uncompleted }, class_name: 'Need'

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -35,4 +35,13 @@ RSpec.describe Contact, type: :model do
     valid_contact = build :contact, first_name: 'John', middle_names: 'Ryan', surname: 'Doe', date_of_birth: 'abc'
     expect(valid_contact.valid?).to be_falsy
   end
+
+  describe '#strip_whitespace' do
+    it 'removes whitespace around fields that respond to the #strip method' do
+      valid_contact = create :contact, first_name: '     Marcy', middle_names: 'Sarah Marie ', surname: ' Smith-Williams', date_of_birth: '1/12/1986'
+      expect(valid_contact.first_name).to eq 'Marcy'
+      expect(valid_contact.middle_names).to eq 'Sarah Marie'
+      expect(valid_contact.surname).to eq 'Smith-Williams'
+    end
+  end
 end


### PR DESCRIPTION
This is to prevent future duplicates entering the system via user input on the `Add person form`

`Mark     ` will become `Mark`

A separate PR will be rasied to clean existing data