### PR TITLE
Run rake task to strip whitespace from existing contacts

### DIFF
--- a/app/models/concerns/stripable.rb
+++ b/app/models/concerns/stripable.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-module CleanData
+module Stripable
   extend ActiveSupport::Concern
 
   # Strip Leading and Trailing Whitespace from text and string fields
   # Include on an ApplicationRecord object via:
-  # 'include CleanData'
+  # 'include Stripable'
   module ClassMethods
     # If only would like to strip whitespace from specific attributes/fields
     # 'trim_fields :first_name, :middle_names, :surname'

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -3,7 +3,7 @@
 class Contact < ApplicationRecord
   require 'activerecord-import/base'
   require 'activerecord-import/active_record/adapters/postgresql_adapter'
-  include CleanData
+  include Stripable
 
   before_validation :strip_whitespace_from_all_text_and_strings
 

--- a/lib/historic_data_cleaner.rb
+++ b/lib/historic_data_cleaner.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+class HistoricDataCleaner
+  BATCH_SIZE = 5
+  DOUBLE_LINE = '================================================='
+  FAILURE = '❌'
+  LINE = '------------------------------------'
+  PASS = '✅'
+
+  def self.call(object, caller, fields_to_update)
+    new(object, caller, fields_to_update)
+  end
+
+  attr_reader :multi_logger
+
+  def initialize(object, caller, fields_to_update)
+    @caller = caller
+    @environment_log_message = environment_log_message
+    @fields_to_update = fields_to_update
+    @object_name = object
+    @multi_logger = create_logger
+    @object_statement = []
+    @updated_records = []
+    @invalid_records = []
+    @processed_count = 0
+    @updated_count = 0
+    @not_updated_count = 0
+  end
+
+  def cleanse
+    log_start
+    validate_object
+    build_object_statement
+    validate_object_statement
+    process_in_batches
+    report_success_and_errors
+  end
+
+  private
+
+  attr_accessor :object_statement, :updated_records, :invalid_records, :processed_count, :updated_count, :not_updated_count
+  attr_reader :fields_to_update, :object
+
+  def caller=(caller)
+    @caller = caller.include?(':') ? caller.split(':').join('-') : caller
+  end
+
+  def environment_log_message
+    case Rails.env
+    when 'development'
+      "\e[1m\e[32m#{Rails.env.upcase}\e[0m"
+    when 'test'
+      "\e[36m#{Rails.env.upcase}\e[0m"
+    when 'production'
+      "\e[31mCAUTION: \u001b[4m\e[0;101m\e[1;97mPRODUCTION\e[0m"
+    else
+      "\e[1;33mWARN: \e[1m\e[1;33m#{Rails.env.upcase}\e[0m"
+    end
+  end
+
+  def create_logger
+    stdout_logger = ActiveSupport::Logger.new(STDOUT)
+    file_logger = ActiveSupport::Logger.new("log/#{@caller}_#{@object_name}_#{Rails.env}.log")
+    multi_logger = stdout_logger.extend(ActiveSupport::Logger.broadcast(file_logger))
+    multi_logger.level = Logger::INFO
+
+    original_formatter = Logger::Formatter.new
+    file_logger.formatter = proc { |severity, datetime, progname, msg|
+      original_formatter.call(severity, datetime, progname, msg)
+    }
+    multi_logger
+  end
+
+  def log_start
+    log "\u001b[0m\u001b[7m ENVIRONMENT ** \e[0m #{environment_log_message} \u001b[0m\u001b[7m ** ENVIRONMENT \e[0m\n"
+    log "#{Time.now}  \e[1m\e[33m__START__\e[0m"
+    msg = "Processing Data Cleanup Request for #{@object_name.capitalize}s"
+    log msg
+    puts DOUBLE_LINE
+  end
+
+  def log(msg, status = :info)
+    severity = Object.const_get("#{Logger}::#{status.to_s.upcase}")
+    multi_logger.add(severity, msg, self.class.name)
+  end
+
+  def validate_object
+    @object = @object_name.to_s.classify.constantize
+  rescue NameError => e
+    log("#{e.class}: #{e.message}", :fatal)
+    log("\e[31mPlease check the name of the model/table is correct - Exiting\e[0m")
+    exit 90
+  end
+
+  def build_object_statement
+    log "Fields/columns/attributes - targeted\n#{LINE}"
+    fields_to_update.each do |field|
+      log field
+      object_statement << "LENGTH(RTRIM(LTRIM(#{field}))) <> LENGTH(#{field})"
+    end
+    puts LINE + "\n"
+  end
+
+  def validate_object_statement
+    valid_fields = object.attribute_names.select { |name| [:string, :text].include?(object.type_for_attribute(name).type) }
+    invalid_fields = fields_to_update - valid_fields
+    return unless invalid_fields.any?
+
+    log('ActiveRecord::InvalidStatement would be raised', :fatal)
+    invalid_fields.each do |field|
+      log("column \e[31m#{@object_name}.#{field}\e[0m does not exist")
+    end
+    log("\e[31mPlease check the name of the fields are correct - Exiting\e[0m")
+    exit 95
+  end
+
+  def process_in_batches
+    temp_updated_records = []
+    log "BATCH_SIZE: #{BATCH_SIZE}\n#{LINE}"
+
+    # Process in batches set by the batch size 1000 is default.
+    object
+      .where(object_statement.join(' OR '))
+      .find_in_batches(batch_size: BATCH_SIZE)
+      .with_index do |group, batch|
+        temp_updated_records = []
+        msg = "\nProcessing batch #{batch} (#{group.size} records)"
+        print msg
+        msg = '.'
+
+        group.each do |record|
+          if record.save(touch: false)
+            @updated_count += 1
+            temp_updated_records << record.id
+            print "\e[32m#{msg}\e[0m"
+          else
+            @not_updated_count += 1
+            @invalid_records << "#{record.id} - #{record.errors.full_messages.to_sentence}"
+            print "\e[31mx\e[0m"
+          end
+          @processed_count += 1
+        end
+        @updated_records << temp_updated_records
+      end
+  end
+
+  def report_success_and_errors
+    if updated_records.empty?
+      log "\nZERO records!\n"
+    else
+      log "\n#{LINE}\nTotal Records Processed: #{processed_count}"
+      log "Updated #{PASS} #{updated_count}"
+
+      if not_updated_count.positive?
+        log "Errors #{FAILURE} #{not_updated_count}"
+        log "#{LINE}\nError Records ID & reason\n#{invalid_records.split.join("\n")}"
+      end
+      unless updated_records.flatten.empty?
+        log "#{LINE}\nUpdated Record ID's: \n"
+        log updated_records.map(&:to_s)
+      end
+    end
+    log "\n#{Time.now}  \e[1m\e[33m__END__\e[0m\n"
+  end
+end

--- a/lib/historic_data_cleaner.rb
+++ b/lib/historic_data_cleaner.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class HistoricDataCleaner
-  BATCH_SIZE = 1000
+  BATCH_SIZE = Rails.env.development? || Rails.env.test? ? 5 : 1000
   DOUBLE_LINE = '================================================='
   FAILURE = '❌'
   LINE = '------------------------------------'

--- a/lib/historic_data_cleaner.rb
+++ b/lib/historic_data_cleaner.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class HistoricDataCleaner
-  BATCH_SIZE = 5
+  BATCH_SIZE = 1000
   DOUBLE_LINE = '================================================='
   FAILURE = '❌'
   LINE = '------------------------------------'

--- a/lib/historic_data_cleaner.rb
+++ b/lib/historic_data_cleaner.rb
@@ -14,7 +14,7 @@ class HistoricDataCleaner
   attr_reader :multi_logger
 
   def initialize(object, caller, fields_to_update)
-    @caller = caller
+    self.caller = caller
     @environment_log_message = environment_log_message
     @fields_to_update = fields_to_update
     @object_name = object
@@ -42,7 +42,7 @@ class HistoricDataCleaner
   attr_reader :fields_to_update, :object
 
   def caller=(caller)
-    @caller = caller.include?(':') ? caller.split(':').join('-') : caller
+    @caller = caller.include?(':') ? caller.split(':').join('_') : caller
   end
 
   def environment_log_message

--- a/lib/tasks/strip_whitespace.rake
+++ b/lib/tasks/strip_whitespace.rake
@@ -1,0 +1,18 @@
+require_relative '../historic_data_cleaner'
+
+namespace :strip_whitespace do
+  desc 'Strip whitespace from specified model/table'
+  task :data_cleanup, [:object_name, :first_attribute] => :environment do |t, args|
+    args.with_defaults(object_name: :unspecified, first_attribute: :unspecified)
+    abort 'Missing Arguments! Exiting' if args[:object_name] == :unspecified || args[:first_attribute] == :unspecified
+
+    fields_to_update = [ args[:first_attribute] ]
+    if args.extras.any?
+      fields_to_update.push args.extras
+    else
+      fields_to_update = args[:first_attribute]
+    end
+
+    HistoricDataCleaner.call(args[:object_name], t.name, fields_to_update.flatten).cleanse
+  end
+end

--- a/lib/tasks/strip_whitespace.rake
+++ b/lib/tasks/strip_whitespace.rake
@@ -6,7 +6,7 @@ namespace :strip_whitespace do
     args.with_defaults(object_name: :unspecified, first_attribute: :unspecified)
     abort 'Missing Arguments! Exiting' if args[:object_name] == :unspecified || args[:first_attribute] == :unspecified
 
-    fields_to_update = [ args[:first_attribute] ]
+    fields_to_update = [args[:first_attribute]]
     if args.extras.any?
       fields_to_update.push args.extras
     else


### PR DESCRIPTION
The PR can be used to strip whitespace from any table/model within the Beacon app.

### How to strip whitespace from a model

The core functionality was extracted from the original rake task (not committed) written to solve the Contacts table whitespace search issue. This is now located in the `HistoricDataCleaner` class. 
The object of interest calls `save` which will update all records that are returned in the `#process_in_batches`.

The save method is dependant on the model concern `stripable`.

The class can be either called directly, or as is proposed from a Rake task.

### Rake Task

`rake -T | grep strip`

`rake strip_whitespace:data_cleanup[object_name,first_attribute]  # Strip whitespace from specified model/table`

The task is namespaced (strip_whitespace) and is called `data_cleanup`. It takes two arguments:
- table/model name (singular)
- table fields/model.attribute_names of the string/text fields to be updated


Example rake command:

`RAILS_ENV=<target_environment> bundle exec rake strip_whitespace:data_cleanup[<model/object>,<field/attribute_1>]` at a minimum.

```
RAILS_ENV=development bundle exec rake strip_whitespace:data_cleanup[contacts,first_name,middle_names,surname]
```

### Output (STDOUT/Log file)

Two output streams are broadcast to as a result of the call to `#create_logger`

A log file is generated named as follows:

`log/<caller>_<object_name>_<Rails.env>.log`

- `caller` is the name of the calling program - for the rake task it is `namespace_taskname`
- `object_name` is the name of the model/table (singular) that is the target of the operation
- `Rails.env` - hopefully self explanatory

In addition to a log file being generated, logging also is sent to STDOUT (terminal/console)

### Successful Run
A successful run will generate output as per the screenshot below.

![STDOUT-successful-run-with-two-errors](https://user-images.githubusercontent.com/37293320/102116440-e1a76e80-3e34-11eb-9cab-3d8bd32324bc.png)

In this run there are two records which have failed, marked with a red `X` during the run and in the generated report.
Both the records have the ID and reason displayed in teh `Error Records ID & reason` section.

To test, I had an additional rake task to update some data. See section `Non commited rake task (data setup)`


### Possible Errors (from rake task)
There are several scenarios whereby errors may be encountered. Each of these are documented with screenshots showing what caused them and the output (terminal screenshots)

#### Passing an incorrect object/table name

![STDOUT-invalid-table-object-name-passed](https://user-images.githubusercontent.com/37293320/102116914-8fb31880-3e35-11eb-9b46-42d68c95ace5.png)


#### Passing incorrect field/attribute names

![STDOUT-invalid-field-or-attribute-names-passed](https://user-images.githubusercontent.com/37293320/102117223-f89a9080-3e35-11eb-82b0-0d74e68175de.png)


### Alternate environments

At the top of the output clearly shows the environment targeted.

![STDOUT-test-environment](https://user-images.githubusercontent.com/37293320/102117635-79598c80-3e36-11eb-80fd-3da984b25864.png)

![STDOUT-production-environment (mocked with development)](https://user-images.githubusercontent.com/37293320/102117672-82e2f480-3e36-11eb-99eb-1cf5fba586c3.png)


#### Example log file output

![strip_whitespace_data_cleanup_contact_development log](https://user-images.githubusercontent.com/37293320/102118556-c4c06a80-3e37-11eb-9b6d-82079bf3cdd8.png)




### Non-commited Rake task

The following rake task was used to test/develop this feature

```ruby
    task backup_setup_data: :environment do
      ActiveRecord::Base.connection.execute(
      "
      UPDATE contacts SET first_name = '',     middle_names = 'Lana',                 surname = '  Bergstrom   '                WHERE id = 98;
      UPDATE contacts SET first_name = '',     middle_names = 'Gerlach',              surname = ' Nikolaus '                    WHERE id = 99;

      UPDATE contacts SET first_name = 'Laurel',         middle_names = 'Windler',              surname = 'Brekke'              WHERE id = 100;
      UPDATE contacts SET first_name = 'Noah',           middle_names = 'Kris',                 surname = 'Kuvalis    '         WHERE id = 101;
      UPDATE contacts SET first_name = '    Demetrius ', middle_names = 'Ryan',                 surname = '          Barrows  ' WHERE id = 102;
      UPDATE contacts SET first_name = '    Shirley ',   middle_names = 'Cassin',               surname = '     Ward    '       WHERE id = 103;
      UPDATE contacts SET first_name = '    Rickie ',    middle_names = 'Vandervort',           surname = 'Lind    '            WHERE id = 104;
      UPDATE contacts SET first_name = ' Mckinley   ',   middle_names = 'Pfannerstill',         surname = ' Pagac'              WHERE id = 105;
      UPDATE contacts SET first_name = ' Kathlene   ',   middle_names = 'Zieme',                surname = '     Johnston'       WHERE id = 106;
      UPDATE contacts SET first_name = ' Refugio   ',    middle_names = 'Bergstrom',            surname = '  Casper           ' WHERE id = 107;
      UPDATE contacts SET first_name = '  Keren    ',    middle_names = 'Heaney',               surname = '   Greenholt '       WHERE id = 108;
      UPDATE contacts SET first_name = '   Carley    ',  middle_names = 'Muller',               surname = '   Effertz  '        WHERE id = 109;
      UPDATE contacts SET first_name = '  Arlyne',       middle_names = 'Swaniawski',           surname = '  Wolf  '            WHERE id = 110;
      UPDATE contacts SET first_name = '   Elna ',       middle_names = 'Bernier',              surname = 'Cassin '             WHERE id = 111;
      UPDATE contacts SET first_name = '   Barney  ',    middle_names = 'Berge',                surname = '  Shanahan'          WHERE id = 112;
      UPDATE contacts SET first_name = '   Stan   ',     middle_names = 'Baumbach',             surname = '  Terry   '          WHERE id = 113;
      UPDATE contacts SET first_name = '  Missy    ',    middle_names = 'Cronin',               surname = ' Olson '             WHERE id = 114;
      UPDATE contacts SET first_name = ' Timmy',         middle_names = 'Becker',               surname = '   Hackett'          WHERE id = 115;
      UPDATE contacts SET first_name = ' Jeneva',        middle_names = 'Wuckert',              surname = '  OConnell'          WHERE id = 116;
      UPDATE contacts SET first_name = '   Johnnie',     middle_names = 'Ankunding',            surname = ' Macejkovic   '      WHERE id = 117;
      UPDATE contacts SET first_name = '    Julius',     middle_names = 'Bauch',                surname = 'Jakubowski  '        WHERE id = 118;
      UPDATE contacts SET first_name = 'Marketta  ',     middle_names = 'Harris',               surname = 'Dach        '        WHERE id = 119;
      UPDATE contacts SET first_name = 'Arnulfo  ',      middle_names = 'Breitenberg',          surname = 'Littel '             WHERE id = 120;
      UPDATE contacts SET first_name = 'Leigha ',        middle_names = 'Legros',               surname = '    Rohan'           WHERE id = 121;
      UPDATE contacts SET first_name = ' Jarred ',       middle_names = 'Cormier',              surname = '    Mraz   '         WHERE id = 122;
      UPDATE contacts SET first_name = 'Laurence  ',     middle_names = 'Schmeler',             surname = 'Herman '             WHERE id = 123;
      UPDATE contacts SET first_name = 'Katy   ',        middle_names = 'Turcotte',             surname = ' Buckridge'          WHERE id = 124;
      UPDATE contacts SET first_name = 'Donovan   ',     middle_names = 'Metz',                 surname = '  Schiller'          WHERE id = 125;
      UPDATE contacts SET first_name = 'Trinity    ',    middle_names = 'Schmeler',             surname = '  Abbott   '         WHERE id = 126;
      UPDATE contacts SET first_name = '   Kelli',       middle_names = 'Block',                surname = 'Ondricka   '         WHERE id = 127;
      UPDATE contacts SET first_name = '  Olivia',       middle_names = 'Wilkinson',            surname = 'Schaden  '           WHERE id = 128;
      UPDATE contacts SET first_name = ' Claudia ',      middle_names = 'Schuster',             surname = 'Crist   '            WHERE id = 129;
      UPDATE contacts SET first_name = 'Tiffanie  ',     middle_names = 'Metz',                 surname = 'Macejkovic'          WHERE id = 130;
      UPDATE contacts SET first_name = '  Guy ',         middle_names = 'Jaskolski',            surname = '    Leannon'         WHERE id = 131;
      UPDATE contacts SET first_name = '    Irving    ', middle_names = 'Klein',                surname = '  Brown     '        WHERE id = 132;
      UPDATE contacts SET first_name = 'Seth',           middle_names = 'Walter',               surname = 'Daugherty   '        WHERE id = 133;
      UPDATE contacts SET first_name = '    Danilo',     middle_names = 'Gerlach',              surname = ' Nikolaus '          WHERE id = 134;
      "
      ) # 35 records
    end
```

Embeded as an additonal task in the existing namespace.

