### PR TITLE
Make magic links work on docker (development)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,5 +17,7 @@ services:
       - .:/app
     ports:
       - "3000:3000"
+    environment:
+      - HOSTNAME=localhost:3000
     depends_on:
       - postgresql


### PR DESCRIPTION
Tiny fix so that magic links change in the logs in development to be usable

Prior to this fix in docker we got:

```
This is a GOV.UK Notify email with template 47da4e5d-ef0d-4ab7-91ee-eb96baa4ed07 and personalisation: {:magic_link=>"http://87dcf0846660/sign_in/zgZvApDer6KScN-H9RGYdcB9vnHlXoEtZwi2gwGsMkY", :timeout=>60}
```

With this fix will get:
```
This is a GOV.UK Notify email with template 47da4e5d-ef0d-4ab7-91ee-eb96baa4ed07 and personalisation: {:magic_link=>"http://localhost:3000/sign_in/bxK3E0DU3DCu-emCtpi1dnsdMihE98rwWWc4Y3q-_EY", :timeout=>60}
```
