### PR TITLE
Add 2 additional fields to data import

### DIFF
--- a/app/controllers/imported_items_controller.rb
+++ b/app/controllers/imported_items_controller.rb
@@ -24,15 +24,15 @@ class ImportedItemsController < ApplicationController
     ImportedItem.transaction do
       imported_item = ImportedItem.create! name: @params[:imported_item_name]
       unique_contacts, not_unique_contacts = imported_item.import(@params.slice(:file))
-      Rails.logger.unknown('User imported new contacts')
       raise ActiveRecord::Rollback if unique_contacts.empty?
 
+      Rails.logger.unknown('User imported new contacts')
       redirect_to imported_items_path(order: 'created_at', order_dir: 'DESC'), notice: import_msg(unique_contacts, not_unique_contacts)
     rescue ActiveRecord::RecordInvalid => e
       flash[:error] = e.message
       render :new
     rescue ActiveRecord::Rollback
-      flash[:error] = 'Please enter at leat one unique contact'
+      flash[:error] = 'Please enter at least one unique contact'
       render :new
       raise ActiveRecord::Rollback
     end

--- a/app/controllers/imported_items_controller.rb
+++ b/app/controllers/imported_items_controller.rb
@@ -24,15 +24,15 @@ class ImportedItemsController < ApplicationController
     ImportedItem.transaction do
       imported_item = ImportedItem.create! name: @params[:imported_item_name]
       unique_contacts, not_unique_contacts = imported_item.import(@params.slice(:file))
+      Rails.logger.unknown('User imported new contacts')
       raise ActiveRecord::Rollback if unique_contacts.empty?
 
-      Rails.logger.unknown('User imported new contacts')
       redirect_to imported_items_path(order: 'created_at', order_dir: 'DESC'), notice: import_msg(unique_contacts, not_unique_contacts)
     rescue ActiveRecord::RecordInvalid => e
       flash[:error] = e.message
       render :new
     rescue ActiveRecord::Rollback
-      flash[:error] = 'Please enter at least one unique contact'
+      flash[:error] = 'Please enter at leat one unique contact'
       render :new
       raise ActiveRecord::Rollback
     end

--- a/app/models/imported_item.rb
+++ b/app/models/imported_item.rb
@@ -17,25 +17,25 @@ class ImportedItem < ApplicationRecord
       contacts_rows << row
     end
 
-    unique_contacts, not_unique_contacts = unique_and_non_unique_records contacts_rows
+    unique_contacts, not_unique_contacts = unique_records contacts_rows
 
     contacts = []
-    unique_contacts.each do |contact_record|
+    unique_contacts.each do |row|
       contacts << Contact.new(
-        test_and_trace_account_id: contact_record[0],
-        nhs_number: contact_record[1],
-        is_vulnerable: (contact_record[2] == 1 || contact_record[2].to_s.downcase == 'true'),
-        first_name: contact_record[3],
-        surname: contact_record[4],
-        date_of_birth: contact_record[5],
-        email: contact_record[6],
-        mobile: contact_record[7],
-        telephone: contact_record[8],
-        address: contact_record[9],
-        postcode: contact_record[10],
-        needs: [Need.new(category: 'Check in', start_on: Date.today + 2.days, name: contact_record[11])],
-        test_trace_creation_date: contact_record[12],
-        isolation_start_date: contact_record[13],
+        test_and_trace_account_id: row[0],
+        nhs_number: row[1],
+        is_vulnerable: (row[2] == 1 || row[2].to_s.downcase == 'true'),
+        first_name: row[3],
+        surname: row[4],
+        date_of_birth: row[5],
+        email: row[6],
+        mobile: row[7],
+        telephone: row[8],
+        address: row[9],
+        postcode: row[10],
+        needs: [Need.new(category: 'Check in', start_on: Date.today + 2.days, name: row[11])],
+        test_trace_creation_date: row[12],
+        isolation_start_date: row[13],
         imported_item: self
       )
     end
@@ -45,26 +45,26 @@ class ImportedItem < ApplicationRecord
 
   private
 
-  def unique_and_non_unique_records(records)
+  def unique_records(rows)
     not_unique_records = []
     unique_records = []
-    records.each do |record|
-      if check_record(record)
-        not_unique_records << record
+    rows.each do |row|
+      if check_row(row)
+        not_unique_records << row
       else
-        unique_records << record
+        unique_records << row
       end
     end
     [unique_records, not_unique_records]
   end
 
-  def check_record(record)
-    if not_empty(record[0]) && not_zero(Contact.where('test_and_trace_account_id = ?', record[0].to_s))
-      record
-    elsif not_empty(record[1]) && not_zero(Contact.where('nhs_number = ?', record[1].to_s))
-      record
-    elsif not_empty_name(record)
-      record
+  def check_row(row)
+    if not_empty(row[0]) && not_zero(Contact.where('test_and_trace_account_id = ?', row[0].to_s))
+      row
+    elsif not_empty(row[1]) && not_zero(Contact.where('nhs_number = ?', row[1].to_s))
+      row
+    elsif not_empty_name(row)
+      row
     end
   end
 
@@ -76,7 +76,7 @@ class ImportedItem < ApplicationRecord
     !records.count.zero?
   end
 
-  def not_empty_name(record)
-    not_empty(record[3]) && not_empty(record[4]) && not_zero(Contact.where('lower(first_name) = lower(?) and lower(surname) = lower(?)', record[3], record[4]))
+  def not_empty_name(row)
+    not_empty(row[3]) && not_empty(row[4]) && not_zero(Contact.where('lower(first_name) = lower(?) and lower(surname) = lower(?)', row[3], row[4]))
   end
 end

--- a/app/models/imported_item.rb
+++ b/app/models/imported_item.rb
@@ -17,25 +17,25 @@ class ImportedItem < ApplicationRecord
       contacts_rows << row
     end
 
-    unique_contacts, not_unique_contacts = unique_records contacts_rows
+    unique_contacts, not_unique_contacts = unique_and_non_unique_records contacts_rows
 
     contacts = []
-    unique_contacts.each do |row|
+    unique_contacts.each do |contact_record|
       contacts << Contact.new(
-        test_and_trace_account_id: row[0],
-        nhs_number: row[1],
-        is_vulnerable: (row[2] == 1 || row[2].to_s.downcase == 'true'),
-        first_name: row[3],
-        surname: row[4],
-        date_of_birth: row[5],
-        email: row[6],
-        mobile: row[7],
-        telephone: row[8],
-        address: row[9],
-        postcode: row[10],
-        needs: [Need.new(category: 'Check in', start_on: Date.today + 2.days, name: row[11])],
-        test_trace_creation_date: row[12],
-        isolation_start_date: row[13],
+        test_and_trace_account_id: contact_record[0],
+        nhs_number: contact_record[1],
+        is_vulnerable: (contact_record[2] == 1 || contact_record[2].to_s.downcase == 'true'),
+        first_name: contact_record[3],
+        surname: contact_record[4],
+        date_of_birth: contact_record[5],
+        email: contact_record[6],
+        mobile: contact_record[7],
+        telephone: contact_record[8],
+        address: contact_record[9],
+        postcode: contact_record[10],
+        needs: [Need.new(category: 'Check in', start_on: Date.today + 2.days, name: contact_record[11])],
+        test_trace_creation_date: contact_record[12],
+        isolation_start_date: contact_record[13],
         imported_item: self
       )
     end
@@ -45,26 +45,26 @@ class ImportedItem < ApplicationRecord
 
   private
 
-  def unique_records(rows)
+  def unique_and_non_unique_records(records)
     not_unique_records = []
     unique_records = []
-    rows.each do |row|
-      if check_row(row)
-        not_unique_records << row
+    records.each do |record|
+      if check_record(record)
+        not_unique_records << record
       else
-        unique_records << row
+        unique_records << record
       end
     end
     [unique_records, not_unique_records]
   end
 
-  def check_row(row)
-    if not_empty(row[0]) && not_zero(Contact.where('test_and_trace_account_id = ?', row[0].to_s))
-      row
-    elsif not_empty(row[1]) && not_zero(Contact.where('nhs_number = ?', row[1].to_s))
-      row
-    elsif not_empty_name(row)
-      row
+  def check_record(record)
+    if not_empty(record[0]) && not_zero(Contact.where('test_and_trace_account_id = ?', record[0].to_s))
+      record
+    elsif not_empty(record[1]) && not_zero(Contact.where('nhs_number = ?', record[1].to_s))
+      record
+    elsif not_empty_name(record)
+      record
     end
   end
 
@@ -76,7 +76,7 @@ class ImportedItem < ApplicationRecord
     !records.count.zero?
   end
 
-  def not_empty_name(row)
-    not_empty(row[3]) && not_empty(row[4]) && not_zero(Contact.where('lower(first_name) = lower(?) and lower(surname) = lower(?)', row[3], row[4]))
+  def not_empty_name(record)
+    not_empty(record[3]) && not_empty(record[4]) && not_zero(Contact.where('lower(first_name) = lower(?) and lower(surname) = lower(?)', record[3], record[4]))
   end
 end

--- a/app/models/imported_item.rb
+++ b/app/models/imported_item.rb
@@ -34,6 +34,8 @@ class ImportedItem < ApplicationRecord
         address: row[9],
         postcode: row[10],
         needs: [Need.new(category: 'Check in', start_on: Date.today + 2.days, name: row[11])],
+        test_trace_creation_date: row[12],
+        isolation_start_date: row[13],
         imported_item: self
       )
     end

--- a/db/migrate/20201215112311_add_test_trace_creation_date_and_isolation_start_date_to_contacts.rb
+++ b/db/migrate/20201215112311_add_test_trace_creation_date_and_isolation_start_date_to_contacts.rb
@@ -1,0 +1,6 @@
+class AddTestTraceCreationDateAndIsolationStartDateToContacts < ActiveRecord::Migration[6.0]
+  def change
+  	add_column :contacts, :test_trace_creation_date, :date
+  	add_column :contacts, :isolation_start_date, :date
+  end
+end

--- a/db/migrate/20201215112311_add_test_trace_creation_date_and_isolation_start_date_to_contacts.rb
+++ b/db/migrate/20201215112311_add_test_trace_creation_date_and_isolation_start_date_to_contacts.rb
@@ -1,6 +1,6 @@
 class AddTestTraceCreationDateAndIsolationStartDateToContacts < ActiveRecord::Migration[6.0]
   def change
-  	add_column :contacts, :test_trace_creation_date, :date
-  	add_column :contacts, :isolation_start_date, :date
+    add_column :contacts, :test_trace_creation_date, :date
+    add_column :contacts, :isolation_start_date, :date
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_19_125747) do
+ActiveRecord::Schema.define(version: 2020_12_15_112311) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,6 +48,8 @@ ActiveRecord::Schema.define(version: 2020_11_19_125747) do
     t.string "lead_service_note"
     t.bigint "imported_item_id"
     t.string "test_and_trace_account_id"
+    t.date "test_trace_creation_date"
+    t.date "isolation_start_date"
   end
 
   create_table "imported_items", force: :cascade do |t|


### PR DESCRIPTION
Add additional fields from import spreadsheet

- `test_trace_creation_date`
- `isolation_start_date`

Some minor refactoring to names in import method as `row` did not feel right in all places referenced

Move Rails.logger.unknown message about `User imported new contacts` to after Rollback, as if Rollback occurs then technically zero new records are imported

```ruby
[1] pry(main)> Contact.last
  Contact Load (0.4ms)  SELECT "contacts".* FROM "contacts" ORDER BY "contacts"."id" DESC LIMIT $1  [["LIMIT", 1]]
=> #<Contact:0x00007f7878a037d0
 id: 639,
 first_name: "Casey",
 middle_names: nil,
 surname: "Addams",
 address: "201 White Shires Road",
 postcode: "N1 0AB",
 telephone: nil,
 mobile: "+44762",
 gds_import_data: nil,
 is_vulnerable: false,
 created_at: Tue, 15 Dec 2020 15:45:45 UTC +00:00,
 updated_at: Tue, 15 Dec 2020 15:45:45 UTC +00:00,
 email: nil,
 additional_info: nil,
 count_people_in_house: nil,
 any_children_under_age: nil,
 delivery_details: nil,
 any_dietary_requirements: nil,
 dietary_details: nil,
 cooking_facilities: nil,
 eligible_for_free_prescriptions: nil,
 nhs_number: "100000000",
 date_of_birth: Mon, 15 Feb 1971,
 has_covid_symptoms: nil,
 lock_version: 0,
 channel: nil,
 no_calls_flag: false,
 deceased_flag: false,
 share_data_flag: nil,
 lead_service_id: nil,
 lead_service_note: nil,
 imported_item_id: 44,
 test_and_trace_account_id: "yyddmm20201215",
 test_trace_creation_date: Thu, 03 Dec 2020,
 isolation_start_date: nil>
[2] pry(main)> 

```

![mocked-up-data](https://user-images.githubusercontent.com/37293320/102245227-327e9c00-3ef5-11eb-801d-065cc0a9a335.png)

The last row in `png` is the record above. 