### PR TITLE
Allow manual input of new contact form fields 

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -111,13 +111,39 @@ class ContactsController < ApplicationController
     @teams_options = construct_teams_options
   end
 
-  def contact_params
-    params.require(:contact).permit(:first_name, :middle_names, :surname, :address, :postcode, :email, :telephone,
-                                    :mobile, :additional_info, :is_vulnerable, :count_people_in_house, :any_children_under_age,
-                                    :delivery_details, :any_dietary_requirements, :dietary_details,
-                                    :cooking_facilities, :eligible_for_free_prescriptions, :has_covid_symptoms, :lock_version,
-                                    :channel, :no_calls_flag, :deceased_flag, :share_data_flag, :date_of_birth, :nhs_number,
-                                    :lead_service_id, :lead_service_note, :test_and_trace_account_id)
+  def contact_params # rubocop:disable Metrics/MethodLength
+    params.require(:contact).permit(
+      :additional_info,
+      :address,
+      :any_children_under_age,
+      :any_dietary_requirements,
+      :channel,
+      :cooking_facilities,
+      :count_people_in_house,
+      :date_of_birth,
+      :deceased_flag,
+      :delivery_details,
+      :dietary_details,
+      :eligible_for_free_prescriptions,
+      :email,
+      :first_name,
+      :has_covid_symptoms,
+      :isolation_start_date,
+      :is_vulnerable,
+      :lock_version,
+      :lead_service_id,
+      :lead_service_note,
+      :middle_names,
+      :mobile,
+      :nhs_number,
+      :no_calls_flag,
+      :postcode,
+      :share_data_flag,
+      :surname,
+      :telephone,
+      :test_and_trace_account_id,
+      :test_trace_creation_date
+    )
   end
 
   def extract_role_id(role_id)

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -18,6 +18,8 @@ class Contact < ApplicationRecord
 
   validates :first_name, presence: true
   validates_date :date_of_birth, allow_nil: true, allow_blank: true
+  validates_date :test_trace_creation_date, allow_nil: true, allow_blank: true
+  validates_date :isolation_start_date, allow_nil: true, allow_blank: true
 
   scope :search, lambda { |text|
                    where("first_name ilike ?

--- a/app/views/contacts/_form_fields.html.erb
+++ b/app/views/contacts/_form_fields.html.erb
@@ -21,10 +21,17 @@
     <%= form.label :nhs_number, 'NHS Number', class: "field__label" %>
     <%= form.text_field :nhs_number %>
   </div>
-  
   <div class="field">
     <%= form.label :test_and_trace_account_id, 'Test & Trace Id', class: "field__label" %>
     <%= form.text_field :test_and_trace_account_id %>
+  </div>
+  <div class="field">
+    <%= form.label :test_trace_creation_date, 'Test & Trace Creation Date', class: "field__label" %>
+    <%= form.text_field :test_trace_creation_date, placeholder: 'Eg: 17/12/2020' %>
+  </div>
+  <div class="field">
+    <%= form.label :isolation_start_date, 'Isolation Start Date', class: "field__label" %>
+    <%= form.text_field :isolation_start_date, placeholder: 'Eg: 17/12/2020' %>
   </div>
 </fieldset>
 

--- a/app/views/shared/_profile-accordion-edit.html.erb
+++ b/app/views/shared/_profile-accordion-edit.html.erb
@@ -53,6 +53,16 @@
       <%= form.label :test_and_trace_account_id, "Test & Trace Id", class: "field__label" %>
       <%= form.text_field :test_and_trace_account_id %>
     </div>
+
+    <div class="field">
+      <%= form.label :test_trace_creation_date, 'Test & Trace Creation Date', class: "field__label" %>
+      <%= form.text_field :test_trace_creation_date, placeholder: 'Eg: 17/12/2020', :value => "#{@contact.test_trace_creation_date&.strftime('%-d/%-m/%Y')}" %>
+    </div>
+
+    <div class="field">
+      <%= form.label :isolation_start_date, 'Isolation Start Date', class: "field__label" %>
+      <%= form.text_field :isolation_start_date, placeholder: 'Eg: 17/12/2020', :value => "#{@contact.isolation_start_date&.strftime('%-d/%-m/%Y')}" %>
+    </div>
   </div>
 
   <button type="button" type="button" type="button" class="accordion__control" aria-expanded="true">

--- a/app/views/shared/_profile-accordion.html.erb
+++ b/app/views/shared/_profile-accordion.html.erb
@@ -4,34 +4,49 @@
         <h2 class="accordion__title">Personal details</h2>  
     </button>
     <div class="accordion__content">  
-        <dl class="details-list">
-          <dt class="details-list__caption">Name</dt>
-          <dd class="details-list__value" id="contact_name"><%= @contact.name %></dd>
+      <dl class="details-list">
+        <dt class="details-list__caption">Name</dt>
+        <dd class="details-list__value" id="contact_name">
+          <%= @contact.name %>
+        </dd>
 
-          <dt class="details-list__caption">Date of Birth</dt>
-          <dd class="details-list__value" id="contact_dob"><%= @contact.date_of_birth&.strftime("%-d %B %Y") %></dd>
+        <dt class="details-list__caption">Date of Birth</dt>
+        <dd class="details-list__value" id="contact_dob">
+          <%= @contact.date_of_birth&.strftime("%-d %B %Y") %>
+        </dd>
 
-          <dt class="details-list__caption">Address</dt>
-            <dd class="details-list__value" id="address_details">
-                <%= @contact.address %><br/>
-                <%= @contact.postcode %>
-            </dd>
+        <dt class="details-list__caption">Address</dt>
+          <dd class="details-list__value" id="address_details">
+              <%= @contact.address %><br/>
+              <%= @contact.postcode %>
+          </dd>
 
-            <dt class="details-list__caption">Email</dt>
-            <dd class="details-list__value" id="email_address"><%= dash_if_empty @contact.email %></dd>
+          <dt class="details-list__caption">Email</dt>
+          <dd class="details-list__value" id="email_address">
+            <%= dash_if_empty @contact.email %>
+          </dd>
 
-            <dt class="details-list__caption">Phone</dt>
-            <dd class="details-list__value" id="phone_details">
-                <%= @contact.telephone %><br/>
-                <%= @contact.mobile %>
-            </dd>
-            
-            <dt class="details-list__caption">Test & Trace Id</dt>
-            <dd class="details-list__value" id="test_and_trace_account_id">
-                <%= @contact.test_and_trace_account_id %>
-            </dd>
-        </dl>
+          <dt class="details-list__caption">Phone</dt>
+          <dd class="details-list__value" id="phone_details">
+              <%= @contact.telephone %><br/>
+              <%= @contact.mobile %>
+          </dd>
 
+          <dt class="details-list__caption">Test & Trace Id</dt>
+          <dd class="details-list__value" id="test_and_trace_account_id">
+            <%= @contact.test_and_trace_account_id %>
+          </dd>
+
+          <dt class="details-list__caption">Test & Trace Creation Date</dt>
+          <dd class="details-list__value" id="test_trace_creation_date">
+            <%= @contact.test_trace_creation_date %>
+          </dd>
+
+          <dt class="details-list__caption">Isolation Start Date</dt>
+          <dd class="details-list__value" id="isolation_start_date">
+            <%= @contact.isolation_start_date %>
+          </dd>
+      </dl>
     </div>
 
     <button class="accordion__control" aria-expanded="true">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,6 +43,10 @@ en:
           attributes:
             date_of_birth:
               invalid_date: "must be a valid date"
+            test_trace_creation_date:
+              invalid_date: "must be a valid date"
+            isolation_start_date:
+              invalid_date: "must be a valid date"
 
   passwordless:
     mailer:


### PR DESCRIPTION
- test_trace_creation_date
- isolation_start_date

Also display on relevant pages

[Trello 106](https://trello.com/c/hijZDsyB/106-add-new-fields-to-new-edit-forms-for-contacts)

![Updated-CREATE-Personal-details-screen-with-ttcd-and-isd](https://user-images.githubusercontent.com/37293320/102489034-d8044d80-4064-11eb-8f3d-f84b107a561d.png)
![Updated-EDIT-Personal-details-screen-with-ttcd-and-isd](https://user-images.githubusercontent.com/37293320/102489036-d89ce400-4064-11eb-8c9a-731ab210e46c.png)
![Updated-Personal-details-screen-with-ttcd-and-isd](https://user-images.githubusercontent.com/37293320/102489037-d89ce400-4064-11eb-9d59-3fcdecedd00b.png)

