### PR TITLE
Update rack gem to address CVE-2020-8184

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -225,7 +225,7 @@ GEM
       nio4r (~> 2.0)
     pundit (2.1.0)
       activesupport (>= 3.0.0)
-    rack (2.2.2)
+    rack (2.2.3)
     rack-livereload (0.3.17)
       rack
     rack-proxy (0.6.5)


### PR DESCRIPTION
As noted in the dependabot issues. 