### PR TITLE
Trello-126: - Allow ordering of needs based on 'assigned to'

### DIFF
--- a/app/views/needs/index.html.erb
+++ b/app/views/needs/index.html.erb
@@ -42,7 +42,21 @@
               </div>
             </div>
         </th>
-        <th>Assigned to</th>
+        <th>
+          <div class="sortable">
+            Assigned to
+            <div class="sortable__controls">
+              <%= link_to_unless_current image_tag("sort-asc.svg", alt: "sort ascending"),
+                @params.merge(order: 'assigned_to', order_dir: 'ASC') do %>
+                <%= image_tag "sort-asc-grey.svg", alt: "sorted ascending" %>
+              <% end %>
+              <%= link_to_unless_current image_tag("sort-desc.svg", alt: "sort descending"),
+                @params.merge(order: 'assigned_to', order_dir: 'DESC') do %>
+                <%= image_tag "sort-desc-grey.svg", alt: "sorted descending" %>
+              <% end %>
+            </div>
+          </div>
+        </th>
         <th>
           <div class="sortable">
           Last contacted


### PR DESCRIPTION
[Trello #126 - Sort Needs by 'assigned to' column](https://trello.com/c/uL8qhu1a/126-request)

Example screenshots of solution
![Trello-126-needs-sorting-by-assigned-to-#1](https://user-images.githubusercontent.com/37293320/103710712-9b65ab00-4fad-11eb-9216-70bb813805ed.png)
![Trello-126-needs-sorting-by-assigned-to-#2](https://user-images.githubusercontent.com/37293320/103710714-9bfe4180-4fad-11eb-84c9-417ca837a27e.png)
