### PR TITLE
114 - Add ability to add a business for inbound calls

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -150,7 +150,8 @@ class ContactsController < ApplicationController
       :surname,
       :telephone,
       :test_and_trace_account_id,
-      :test_trace_creation_date
+      :test_trace_creation_date,
+      :business_name
     )
   end
 

--- a/app/views/contacts/_form_fields.html.erb
+++ b/app/views/contacts/_form_fields.html.erb
@@ -14,6 +14,10 @@
     <%= form.text_field :surname %>
   </div>
   <div class="field">
+    <%= form.label :business_name, 'Business name (Optional)', class: "field__label" %>
+    <%= form.text_field :business_name %>
+  </div>
+  <div class="field">
     <%= form.label :date_of_birth, class: "field__label" %>
     <%= form.text_field :date_of_birth, placeholder: 'Eg: 01/11/1943'%>
   </div>

--- a/app/views/shared/_profile-accordion-edit.html.erb
+++ b/app/views/shared/_profile-accordion-edit.html.erb
@@ -21,6 +21,11 @@
     </div>
 
     <div class="field">
+      <%= form.label :business_name, 'Business name (Optional)', class: "field__label" %>
+      <%= form.text_field :business_name %>
+    </div>
+
+    <div class="field">
       <%= form.label :date_of_birth, class: "field__label" %>
       <%= form.text_field :date_of_birth, :value => "#{@contact.date_of_birth&.strftime('%-d/%-m/%Y')}" %>
     </div>

--- a/app/views/shared/_profile-accordion.html.erb
+++ b/app/views/shared/_profile-accordion.html.erb
@@ -10,6 +10,11 @@
           <%= @contact.name %>
         </dd>
 
+        <dt class="details-list__caption">Business name</dt>
+        <dd class="details-list__value" id="contact_business_name">
+          <%= @contact.business_name %>
+        </dd>
+
         <dt class="details-list__caption">Date of Birth</dt>
         <dd class="details-list__value" id="contact_dob">
           <%= @contact.date_of_birth&.strftime("%-d %B %Y") %>

--- a/db/migrate/20210106132742_add_business_name_to_contacts.rb
+++ b/db/migrate/20210106132742_add_business_name_to_contacts.rb
@@ -1,0 +1,5 @@
+class AddBusinessNameToContacts < ActiveRecord::Migration[6.0]
+  def change
+    add_column :contacts, :business_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_16_184644) do
+ActiveRecord::Schema.define(version: 2021_01_06_132742) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,6 +50,7 @@ ActiveRecord::Schema.define(version: 2020_12_16_184644) do
     t.string "test_and_trace_account_id"
     t.date "test_trace_creation_date"
     t.date "isolation_start_date"
+    t.string "business_name"
   end
 
   create_table "imported_items", force: :cascade do |t|

--- a/features/new_person.feature
+++ b/features/new_person.feature
@@ -9,7 +9,21 @@ Feature: Add a new person
     When I add the new person details
     And I save the person form
     Then I see a resident created message
-    Examples: 
+    Examples:
+      | role                              |
+      | manager                           |
+      | agent                             |
+      | mdt                               |
+      | council_service_adult_social_care |
+      | council_service_housing           |
+
+  Scenario Outline: Add new business
+    Given I am logged into the system as a "<role>" user
+    And I chosen to add a new person
+    When I add the new person and their business details
+    And I save the person form
+    Then I see a resident created message
+    Examples:
       | role                              |
       | manager                           |
       | agent                             |

--- a/features/step_definitions/new_person_steps.rb
+++ b/features/step_definitions/new_person_steps.rb
@@ -10,6 +10,14 @@ When('I add the new person details') do
   fill_in('contact_date_of_birth', with: '01/4/1936')
 end
 
+When('I add the new person and their business details') do
+  fill_in('contact_first_name', with: 'Lana')
+  fill_in('contact_surname', with: 'Lee-Cartwright')
+  fill_in('contact_business_name', with: 'White Wedding Photography Limited')
+  fill_in('contact_telephone', with: '02037891234')
+  fill_in('contact_date_of_birth', with: '18/10/1989')
+end
+
 When('I save the person form') do
   click_button('Save')
 end

--- a/features/step_definitions/person_steps.rb
+++ b/features/step_definitions/person_steps.rb
@@ -53,6 +53,12 @@ When(/^I edit the residents name$/) do
   fill_in('contact_surname', with: 'TestSurname')
 end
 
+When(/^I edit the residents business name$/) do
+  visit "contacts/#{@contact.id}"
+  click_and_wait('#edit-contact-link', '#contact_first_name')
+  fill_in('contact_business_name', with: 'The Real DJ Experience')
+end
+
 When("I change someone a resident's name concurrently") do
   visit "contacts/#{@contact.id}"
   click_and_wait('#edit-contact-link', '#contact_first_name')
@@ -191,6 +197,10 @@ end
 
 Then(/^the residents names have been updated$/) do
   expect(page.find_by_id('contact_name')).to have_text('TestFirstName TestMiddle Names TestSurname')
+end
+
+Then(/^the residents business name has been updated$/) do
+  expect(page.find_by_id('contact_business_name')).to have_text('The Real DJ Experience')
 end
 
 Then(/^the residents address has been updated$/) do

--- a/features/update_resident.feature
+++ b/features/update_resident.feature
@@ -19,6 +19,14 @@ Feature: Update person
     Then I see a resident updated message
     And the residents names have been updated
 
+  Scenario: Update business name
+    Given a resident
+    When I edit the residents business name
+    And I save the edit resident form
+    Then I see a resident updated message
+    And the residents business name has been updated
+
+
   Scenario: Person does not answer the phone on attempt 1/2/3
   The feature here is a requirement to capture notes against the person
   or complete the additional information field


### PR DESCRIPTION
[Trello-114](https://trello.com/c/ilRqzfSQ/114-add-ability-to-add-a-business-rather-than-a-person-for-inbound-calls-eg-surname-business)

Added for speed using the old sytling, as it will take a bit longer to build the entire form with the new styles.

![Existing-add-person](https://user-images.githubusercontent.com/37293320/103952635-a731a880-5138-11eb-8ad0-f7455e3a9a0d.png)
![Contact-with-business-name](https://user-images.githubusercontent.com/37293320/103952636-a7ca3f00-5138-11eb-999f-77441ee1dae9.png)
![Old-form-with-addition-of-business-name](https://user-images.githubusercontent.com/37293320/103952638-a862d580-5138-11eb-97cd-2e0741482f83.png)
