### PR TITLE
Trello-131: default sort order is by created_at DESC, N/A when no results

### DIFF
--- a/app/controllers/imported_items_controller.rb
+++ b/app/controllers/imported_items_controller.rb
@@ -6,6 +6,7 @@ class ImportedItemsController < ApplicationController
     @created_item = ImportedItem.where(id: params[:created_id]).first
     @params = params.permit(:page, :order, :order_dir)
     @imported_items = policy_scope(ImportedItem)
+    @imported_items.sort_by(&:created_at)
     @imported_items = @imported_items.filter_and_sort({}, @params.slice(:order, :order_dir))
     @imported_items = @imported_items.page(@params[:page])
     Rails.logger.unknown("User viewed imported contacts table: #{@imported_items.map(&:id)}")

--- a/app/controllers/imported_items_controller.rb
+++ b/app/controllers/imported_items_controller.rb
@@ -22,7 +22,7 @@ class ImportedItemsController < ApplicationController
       begin
         @imported_item.import
         Rails.logger.unknown("User imported new contacts: Import Record ID #{@imported_item.id}, Successful(#{@imported_item.imported}) / Rejected (#{@imported_item.rejected})")
-        redirect_to imported_items_path(order: params[:order], order_dir: params[:order_dir], created_id: @imported_item.id), notice: 'Successfully imported file'
+        redirect_to imported_items_path(order: 'created_at', order_dir: 'DESC', created_id: @imported_item.id), notice: 'Successfully imported file'
       rescue StandardError => e
         logger.error e.message
         logger.error e.backtrace

--- a/app/controllers/imported_items_controller.rb
+++ b/app/controllers/imported_items_controller.rb
@@ -26,7 +26,7 @@ class ImportedItemsController < ApplicationController
       rescue StandardError => e
         logger.error e.message
         logger.error e.backtrace
-        redirect_to imported_items_path(order: params[:order], order_dir: params[:order_dir], created_id: @imported_item.id), notice: 'There was a problem uploading this file'
+        redirect_to imported_items_path(order: 'created_at', order_dir: 'DESC', created_id: @imported_item.id), notice: 'There was a problem uploading this file'
       end
     else
       load_imported_items

--- a/app/views/imported_items/index.html.erb
+++ b/app/views/imported_items/index.html.erb
@@ -86,17 +86,17 @@
                 </div>
                 <div class="o-layout__item u-1-of-12">
                     <div class="b-sm__t b-gray u-pb u-pt">
-                        <%= imported_item.imported %>
+                        <%= imported_item.imported.nil? ? 'N/A' : imported_item.imported %>
                     </div>
                 </div>
                 <div class="o-layout__item u-1-of-12">
                     <div class="b-sm__t b-gray u-pb u-pt">
-                        <%= imported_item.rejected %>
+                        <%= imported_item.rejected.nil? ? 'N/A' : imported_item.rejected %>
                     </div>
                 </div>
                 <div class="o-layout__item u-4-of-12">
                     <div class="b-sm__t b-gray u-pb u-pt l-space-between">
-                        <%= imported_item.user.try(:name) || '&nbsp'.html_safe %>
+                        <%= imported_item.user.try(:name).blank? ? 'N/A' : imported_item.user.name  %>
                         <i class="c-icon c-icon--chevron-right bg-black u-mr"></i>
                     </div>
                 </div>


### PR DESCRIPTION
[Default sort ordered by most recent imports](https://trello.com/c/gKMTgfCZ/131-sort-by-most-recent-first-post-import)


![Trello-131-new-default-sort-order](https://user-images.githubusercontent.com/37293320/104036155-f9230e80-51ca-11eb-9b2a-0372ebdc1795.png)


Also added 'N/A' where no data available for `Imported`, `Rejected` and `Imported By`