### PR TITLE
Titleizes names of contacts and users

### DIFF
--- a/app/models/concerns/name_formatter.rb
+++ b/app/models/concerns/name_formatter.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module NameFormatter
+  extend ActiveSupport::Concern
+
+  # On names which are wholly upcased or downcased this
+  # method will titleize them i.e. 'RENEE MULLAN' becomes
+  # 'Renee Mullan'
+  def format_name(name)
+    [name.upcase, name.downcase].include?(name) ? name.titleize : name
+  end
+end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -4,6 +4,7 @@ class Contact < ApplicationRecord
   require 'activerecord-import/base'
   require 'activerecord-import/active_record/adapters/postgresql_adapter'
   include CleanData
+  include NameFormatter
 
   before_validation :strip_whitespace_from_all_text_and_strings
 
@@ -39,7 +40,7 @@ class Contact < ApplicationRecord
                  }
 
   def name
-    [first_name, middle_names, surname].join(' ')
+    format_name([first_name, middle_names, surname].join(' '))
   end
 
   def support_actions_count

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@
 
 class User < ApplicationRecord
   include PgSearch::Model
+  include NameFormatter
   acts_as_paranoid
 
   has_many :notes
@@ -33,7 +34,7 @@ class User < ApplicationRecord
   end
 
   def name
-    deleted? ? [first_name, last_name, '[X]'].join(' ') : [first_name, last_name].join(' ')
+    format_name(deleted? ? [first_name, last_name, '[X]'].join(' ') : [first_name, last_name].join(' '))
   end
 
   def name_or_email

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Contact, type: :model do
   it { is_expected.to be_versioned }
 
   it '#name' do
-    contact = build :contact, first_name: 'John', middle_names: 'Ryan', surname: 'Doe'
+    contact = build :contact, first_name: 'JOHN', middle_names: 'RYAN', surname: 'DOE'
 
     expect(contact.name).to eq 'John Ryan Doe'
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe User, type: :model do
   it { is_expected.to be_versioned }
 
   it '#name' do
-    user = build :user, first_name: 'John', last_name: 'Doe'
+    user = build :user, first_name: 'john', last_name: 'doe'
 
     expect(user.name).to eq 'John Doe'
   end


### PR DESCRIPTION
Closes https://trello.com/c/zT0LciP2/165-small-improvement-update-names-to-always-be-lowercase-with-capitalised-first-letters