### PR TITLE
Uses default time formatter for visual DOB

### DIFF
--- a/app/helpers/contacts_helper.rb
+++ b/app/helpers/contacts_helper.rb
@@ -4,4 +4,8 @@ module ContactsHelper
   def boolean_formatter(boolean)
     boolean ? 'Yes' : 'No'
   end
+
+  def short_date_formatter(date)
+    date&.to_s(:default)
+  end
 end

--- a/app/views/contacts/_imported_item_contacts.html.erb
+++ b/app/views/contacts/_imported_item_contacts.html.erb
@@ -74,7 +74,7 @@
     </div>
     <div class="o-layout__item u-1-of-10">
       <div class="b-sm__t b-gray u-pb u-pt">
-        <%= contact.date_of_birth %>
+        <%= short_date_formatter(contact.date_of_birth) %>
       </div>
     </div>
     <div class="o-layout__item u-1-of-10">

--- a/app/views/contacts/index.html.erb
+++ b/app/views/contacts/index.html.erb
@@ -45,7 +45,7 @@
               <td><%= contact.address %></td>
               <td><%= contact.postcode %></td>
               <td><%= contact.test_and_trace_account_id %></td>
-              <td><%= contact.date_of_birth %></td>
+              <td><%= short_date_formatter(contact.date_of_birth) %></td>
               <td><%= name_for_lead_service contact.lead_service_id %></td>
             </tr>
           <% end %>
@@ -53,7 +53,7 @@
         </table>
       <% end %>
       <%= render "shared/pagination", model: @contacts %>
-   <% else %>
-     <p class="no-results">No matches</p>
-   <% end %>
+  <% else %>
+    <p class="no-results">No matches</p>
+  <% end %>
 </section>

--- a/app/views/shared/_profile-accordion-edit.html.erb
+++ b/app/views/shared/_profile-accordion-edit.html.erb
@@ -27,7 +27,7 @@
 
     <div class="field">
       <%= form.label :date_of_birth, class: "field__label" %>
-      <%= form.text_field :date_of_birth, :value => "#{@contact.date_of_birth&.strftime('%-d/%-m/%Y')}" %>
+      <%= form.text_field :date_of_birth, :value => "#{short_date_formatter(@contact.date_of_birth)}" %>
     </div>
 
     <div class="field field--span-two-cols">

--- a/app/views/shared/_profile-accordion.html.erb
+++ b/app/views/shared/_profile-accordion.html.erb
@@ -17,7 +17,7 @@
 
         <dt class="details-list__caption">Date of Birth</dt>
         <dd class="details-list__value" id="contact_dob">
-          <%= @contact.date_of_birth&.strftime("%-d %B %Y") %>
+          <%= short_date_formatter(@contact.date_of_birth) %>
           <% if @contact.under_18? %>
             <span class='under-18'> (Under 18)</span>
           <% end %>


### PR DESCRIPTION
Closes [Trello 164](https://trello.com/c/trEZv0pz/164-small-improvement-change-the-date-of-birth-day-month-year-to-be-dd-mm-yyyy-throughout)

I just used the default time formatter in the config folder (`config/initializers/time_formats.rb`) 