### PR TITLE
Prepends 0 to contact phone numbers when not there

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -5,6 +5,8 @@ class Contact < ApplicationRecord
   require 'activerecord-import/active_record/adapters/postgresql_adapter'
   include CleanData
   include NameFormatter
+  before_save :update_telephone
+  before_save :update_mobile
 
   before_validation :strip_whitespace_from_all_text_and_strings
 
@@ -59,5 +61,27 @@ class Contact < ApplicationRecord
     return false if date_of_birth.blank?
 
     ((Time.zone.now.beginning_of_day - date_of_birth.to_time) / 1.year.seconds).floor < 18
+  end
+
+  def valid_telephone_number?
+    telephone.nil? || telephone.starts_with?('0') || telephone.starts_with?('+')
+  end
+
+  def valid_mobile_number?
+    mobile.nil? || mobile.starts_with?('0') || mobile.starts_with?('+')
+  end
+
+  private
+
+  def update_telephone
+    return if valid_telephone_number?
+
+    self.telephone = telephone.prepend('0')
+  end
+
+  def update_mobile
+    return if valid_mobile_number?
+
+    self.mobile = mobile.prepend('0')
   end
 end

--- a/db/migrate/20210520091922_update_telephone_prepended_zero_contacts.rb
+++ b/db/migrate/20210520091922_update_telephone_prepended_zero_contacts.rb
@@ -1,0 +1,9 @@
+class UpdateTelephonePrependedZeroContacts < ActiveRecord::Migration[6.0]
+  def change
+    Contact.all.each do |contact|
+      contact.update(telephone: contact.telephone.prepend('0')) unless contact.valid_telephone_number?
+
+      contact.update(mobile: contact.mobile.prepend('0')) unless contact.valid_mobile_number?
+    end
+  end
+end

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -64,4 +64,76 @@ RSpec.describe Contact, type: :model do
       expect(over_18_contact.under_18?).to be_falsy
     end
   end
+
+  describe '#valid_telephone_number?' do
+    it 'valid when starts with 0' do
+      valid_telephone = build :contact, telephone: '0123'
+      expect(valid_telephone.valid_telephone_number?).to be_truthy
+    end
+
+    it 'valid when starts with +' do
+      valid_telephone = build :contact, telephone: '+44123'
+      expect(valid_telephone.valid_telephone_number?).to be_truthy
+    end
+
+    it 'invalid when starts with not 0 or +' do
+      invalid_telephone = build :contact, telephone: '123'
+      expect(invalid_telephone.valid_telephone_number?).to be_falsy
+    end
+  end
+
+  describe '#valid_mobile_number?' do
+    it 'valid when starts with 0' do
+      valid_mobile = build :contact, mobile: '0123'
+      expect(valid_mobile.valid_mobile_number?).to be_truthy
+    end
+
+    it 'valid when starts with +' do
+      valid_mobile = build :contact, mobile: '+44123'
+      expect(valid_mobile.valid_mobile_number?).to be_truthy
+    end
+
+    it 'invalid when starts with not 0 or +' do
+      invalid_mobile = build :contact, mobile: '123'
+      expect(invalid_mobile.valid_mobile_number?).to be_falsy
+    end
+  end
+
+  it 'prepends a zero to telephone if needed' do
+    contact = build :contact, telephone: '123'
+
+    contact.save
+
+    expect(contact.telephone).to eq('0123')
+  end
+
+  it 'prepends a zero to mobile if needed' do
+    contact = build :contact, mobile: '123'
+
+    contact.save
+
+    expect(contact.mobile).to eq('0123')
+  end
+
+  it 'doesn\'t change telephone if it starts with 0 or +' do
+    contact = build :contact, telephone: '0123'
+    contact1 = build :contact, telephone: '+44'
+
+    contact.save
+    contact1.save
+
+    expect(contact.telephone).to eq('0123')
+    expect(contact1.telephone).to eq('+44')
+  end
+
+  it 'doesn\'t change mobile if it starts with 0 or +' do
+    contact = build :contact, mobile: '0123'
+    contact1 = build :contact, mobile: '+44'
+
+    contact.save
+    contact1.save
+
+    expect(contact.mobile).to eq('0123')
+    expect(contact1.mobile).to eq('+44')
+  end
 end


### PR DESCRIPTION
Closes [Trello issue #166](https://trello.com/c/kqHPPAOS/166-small-improvement-0-on-the-start-of-phone-numbers)

If a telephone or mobile number does not have a zero or plus at the
start it will have a zero prepended. All existing numbers in the
database are checked and updated with a zero at the beginning if none
exists.