### PR TITLE
Redirects assessment to the assessment and standardises note input

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -166,7 +166,7 @@ class AssessmentsController < ApplicationController
     @note = Note.new(notes_permit_params)
 
     if @need.valid? && @need.save && (notes_permit_params[:body].empty? || @note.valid? && @need.save && @note.save)
-      redirect_to contact_path(@contact)
+      redirect_to need_path(@need)
       return
     end
 

--- a/app/views/assessments/new.html.erb
+++ b/app/views/assessments/new.html.erb
@@ -63,7 +63,7 @@
                 </fieldset>
       
                 
-                <%= notes_fields.text_area :body, placeholder: 'Call notes' %>
+                <%= notes_fields.text_field :body, placeholder: 'Additional notes (optional)' %>
               </div>              
             <% end %>
           <% elsif @type == 'schedule' %>
@@ -78,7 +78,7 @@
             </div>
           <% end %>
 
-          <%= form.button "Save to profile", class: "button button--primary" %>
+          <%= form.button "Save update to call", class: "button button--primary" %>
         <% end %>
         </div>
       </div>

--- a/features/assessment.feature
+++ b/features/assessment.feature
@@ -33,4 +33,5 @@ Feature: Add assessment
     And I choose to log an assessment
     And I enter valid details
     When I save the assessment
+    And I am on their profile page
     Then I see the saved assessment details on the contact

--- a/features/list_support_actions.feature
+++ b/features/list_support_actions.feature
@@ -14,6 +14,7 @@ Feature: List needs
     And I choose to log an assessment
     When I enter valid details
     When I save the assessment
+    And I am on their profile page
     When I view any needs list row for that resident
     Then I see the last contacted date is today
 

--- a/features/step_definitions/assessment_steps.rb
+++ b/features/step_definitions/assessment_steps.rb
@@ -38,7 +38,7 @@ And('I enter valid details') do
 end
 
 When('I save the assessment') do
-  click_button('Save to profile')
+  click_button('Save update to call')
 end
 
 Then('I see the saved assessment details on the contact') do

--- a/spec/controllers/assessments_controller_spec.rb
+++ b/spec/controllers/assessments_controller_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe AssessmentsController do
       allow(@need).to receive(:new).and_return(@test_need)
       allow(@test_need).to receive(:save).and_return(true)
       allow(@test_need).to receive(:valid?).and_return(true)
+      allow(@test_need).to receive(:to_param).and_return(1)
       allow(@test_need).to receive(:category).and_return('test category')
       allow(@test_need).to receive_messages([:status=, :user=, :name=])
 
@@ -71,13 +72,13 @@ RSpec.describe AssessmentsController do
 
     it 'redirects to the contacts show page when successful' do
       post :create, params: { contact_id: 1, type: 'log', need: { category: 'triage' }, note: { body: 'test' } }
-      expect(response).to redirect_to controller: :contacts, action: :show, id: 1
+      expect(response).to redirect_to controller: :needs, action: :show, id: 1
     end
 
     it 'saves the note when the assessment is being logged' do
       expect(@test_note).to receive(:save).and_return(true)
       post :create, params: { contact_id: 1, type: 'log', need: { category: 'triage' }, note: { body: 'test' } }
-      expect(response).to redirect_to controller: :contacts, action: :show, id: 1
+      expect(response).to redirect_to controller: :needs, action: :show, id: 1
     end
 
     it 'tests the need has a start_on date when it is being scheduled' do


### PR DESCRIPTION
From @evanschris 

> When logging a call the first time we want them to be able to add more than one note at a time rather than write all the notes in at once, so when the save button is clicked could we redirect them to the call page itself rather than back to the person's page?
This would mean they could continue to add more notes.
Then the copy changes - could we make the page more similar to the completed page so
change the notes from textarea to input
change the placeholder text to "Additional notes (optional)"
Change the button to "Save update to call"

All addressed in this PR