### PR TITLE
As 2099 call notes order

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -52,7 +52,7 @@ class ContactsController < ApplicationController
 
     @open_needs = policy_scope(@contact.needs, policy_scope_class: ContactNeedsPolicy::Scope)
                   .uncompleted.not_assessments.not_pending
-                  .sort { |a, b| Need.sort_created_and_start_date(a, b) }
+                  .order(created_at: :desc)
 
     @completed_needs = policy_scope(@contact.needs, policy_scope_class: ContactNeedsPolicy::Scope)
                        .completed.not_assessments.not_pending

--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -271,18 +271,6 @@ class Need < ApplicationRecord
     read_attribute('last_phoned_date')
   end
 
-  # This sort method is to first sort future needs (where start_on > today) to the bottom of the list
-  # and then sort by created_at
-  # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-  def self.sort_created_and_start_date(first, second)
-    return first.start_on <=> second.start_on if first.start_on && second.start_on
-    return -1 if first.start_on.nil? && !second.start_on.nil? && second.start_on > DateTime.now
-    return 1 if second.start_on.nil? && !first.start_on.nil? && first.start_on > DateTime.now
-
-    first.created_at <=> second.created_at
-  end
-  # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-
   private
 
   def set_status

--- a/spec/models/need_spec.rb
+++ b/spec/models/need_spec.rb
@@ -67,37 +67,6 @@ RSpec.describe Need, type: :model do
     expect(need5.status_label).to eq 'Cancelled'
   end
 
-  describe 'sort_created_and_start_date' do
-    let!(:created_today_started) { build :need, name: 'created today, no start date', created_at: DateTime.now, start_on: nil }
-    let!(:created_tomorrow_started) { build :need, name: 'created tomorrow, no start date', created_at: DateTime.now + 1.days, start_on: nil }
-
-    let!(:created_today_start_tomorrow) { build :need, name: 'created today, start tomorrow', created_at: DateTime.now, start_on: DateTime.now + 1.days }
-    let!(:created_today_start_today) { build :need, name: 'created today, start today', created_at: DateTime.now.beginning_of_day, start_on: DateTime.now.beginning_of_day }
-
-    it 'sorts needs started in the future to be at the end' do
-      needs = [created_tomorrow_started, created_today_start_tomorrow].sort { |a, b| Need.sort_created_and_start_date(a, b) }
-
-      expect(needs[0].name).to eq 'created tomorrow, no start date'
-      expect(needs[1].name).to eq 'created today, start tomorrow'
-    end
-
-    it 'sorts needs by created date when they have no start date' do
-      needs = [created_tomorrow_started, created_today_started].sort { |a, b| Need.sort_created_and_start_date(a, b) }
-
-      expect(needs[0].name).to eq 'created today, no start date'
-      expect(needs[1].name).to eq 'created tomorrow, no start date'
-    end
-
-    # given two needs, one which has a start date before now, the sorting should ignore the start date
-    # and sort by created date instead
-    it 'sorts needs by created date when they are started' do
-      needs = [created_tomorrow_started, created_today_start_today].sort { |a, b| Need.sort_created_and_start_date(a, b) }
-
-      expect(needs[0].name).to eq 'created today, start today'
-      expect(needs[1].name).to eq 'created tomorrow, no start date'
-    end
-  end
-
   describe 'assing user or team at the same moment' do
     let(:user) { create :user }
     let(:role) { create :role }


### PR DESCRIPTION
We thought we'd fixed this with #452 but it turns out it was the wrong view, the issue was on the 'Past calls' tab of the contacts show page.

I thought about trying to fix the `Need.sort_created_and_start_date` to sort the collection correctly, but it was so complex already and trying to fix it made my head spin, so I decided to bin it.

It's still a fairly ugly solution, but I hope it's less confusing.