### PR TITLE
Update dockerfile to match dependencies from cf paas 1.8.53

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,11 +1,11 @@
 FROM ruby:2.7.5
 
-ENV BUNDLER_VERSION=2.3.4
+ENV BUNDLER_VERSION=2.3.11
 
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb http://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 RUN apt-get update -qq && apt-get install -y nodejs postgresql-client yarn iproute2
-RUN gem install bundler -v 2.3.4
+RUN gem install bundler -v 2.3.11
 RUN gem install foreman
 ENV RAILS_ENV development
 ENV DATABASE_HOST postgresql


### PR DESCRIPTION
Updating dockerfile to match buildpack info from https://github.com/cloudfoundry/ruby-buildpack/releases/tag/v1.8.53

nb. node version on docker image is v12.22.5 which is different from buildpack requirements

```
root@6f54b08bb1d8:/app# apt-cache madison nodejs
    nodejs | 12.22.5~dfsg-2~11u1 | http://deb.debian.org/debian bullseye/main amd64 Packages
    nodejs | 12.22.5~dfsg-2~11u1 | http://security.debian.org/debian-security bullseye-security/main amd64 Packages
```